### PR TITLE
Require specific head movements for liveness

### DIFF
--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -30,11 +30,15 @@
     <string name="si_smart_selfie_instruction_ready_button">I\'m Ready</string>
     <string name="si_smart_selfie_instructions">Put your face inside the oval frame and wait until it turns green</string>
     <string name="si_smart_selfie_directive_smile">Smile!</string>
-    <string name="si_smart_selfie_directive_capturing">Capturing…</string>
     <string name="si_smart_selfie_directive_unable_to_detect_face">Position your face in the oval</string>
     <string name="si_smart_selfie_directive_multiple_faces">Ensure only one face is visible</string>
     <string name="si_smart_selfie_directive_face_too_far">Move closer</string>
     <string name="si_smart_selfie_directive_face_too_close">Move farther away</string>
+    <string name="si_smart_selfie_directive_look_left">Turn your head to the left</string>
+    <string name="si_smart_selfie_directive_look_right">Turn your head to the right</string>
+    <string name="si_smart_selfie_directive_look_up">Point your head up</string>
+    <string name="si_smart_selfie_directive_look_down">Point your head down</string>
+    <string name="si_smart_selfie_directive_look_straight_ahead">Look straight ahead</string>
     <string name="si_smart_selfie_confirmation_dialog_title">Is this a good quality selfie?</string>
     <string name="si_smart_selfie_confirmation_dialog_subtitle">Make sure your whole face is visible and clear</string>
     <string name="si_smart_selfie_confirmation_dialog_confirm_button">Yes, use this</string>


### PR DESCRIPTION
## Summary

Created as a rudimentary proof of concept, this replaces the current smiling requirement with deliberate head movements. Namely:
1. Turn the head to the left (1 liveness image)
2. Turn the head to the right (1 liveness image)
3. Point your head up (1 liveness image)
4. Point your head down (1 liveness image)
5. Look straight ahead (3 liveness images + selfie image)

## Known Issues

- Has not been thoroughly tested
- It probably makes sense to tune this to capture while head movement is in progress/so that we don't have 3 liveness images looking straight ahead