### PR TITLE
Perform background job status polling

### DIFF
--- a/.github/workflows/release_sdk.yaml
+++ b/.github/workflows/release_sdk.yaml
@@ -131,6 +131,6 @@ jobs:
           
           git config --local user.email "${{ github.actor }}@users.noreply.github.com"
           git config --local user.name "${{ github.actor }}"
-          git add VERSION
+          git add ./lib/VERSION
           git commit -m "Prepare for next development iteration"
           git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Changed
 - Updated API key exception error message to be actionable
-- `SmileID.useSandbox` is now publicly accessible
+- `SmileID.useSandbox` getter is now publicly accessible
 
 ### Removed
 - Removed polling from SmartSelfie Authentication, Document Verification, and Biometric KYC. The

--- a/lib/src/main/java/com/smileidentity/SmileID.kt
+++ b/lib/src/main/java/com/smileidentity/SmileID.kt
@@ -35,6 +35,7 @@ object SmileID {
 
     // Can't use lateinit on primitives, this default will be overwritten as soon as init is called
     var useSandbox: Boolean = true
+        private set
 
     internal var apiKey: String? = null
 

--- a/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
@@ -89,7 +89,6 @@ fun MainScreen(
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val bottomNavSelection = uiState.bottomNavSelection
-    val pendingJobCount by viewModel.pendingJobCount.collectAsStateWithLifecycle()
 
     // TODO: Switch to BottomNavigationScreen.entries once we are using Kotlin 1.9
     val bottomNavItems = remember { BottomNavigationScreen.values().toList().toImmutableList() }
@@ -133,7 +132,7 @@ fun MainScreen(
                         BottomBar(
                             bottomNavItems = bottomNavItems,
                             bottomNavSelection = bottomNavSelection,
-                            pendingJobCount = pendingJobCount,
+                            pendingJobCount = uiState.pendingJobCount,
                         ) {
                             navController.navigate(it.route) {
                                 popUpTo(BottomNavigationScreen.Home.route)

--- a/sample/src/main/java/com/smileidentity/sample/model/Job.kt
+++ b/sample/src/main/java/com/smileidentity/sample/model/Job.kt
@@ -96,7 +96,7 @@ fun DocVJobStatusResponse.toJob(userId: String, jobId: String) = toJob(
     jobType = DocumentVerification,
 )
 
-private fun JobStatusResponse.toJob(
+fun JobStatusResponse.toJob(
     userId: String,
     jobId: String,
     jobType: JobType,

--- a/sample/src/main/java/com/smileidentity/sample/viewmodel/JobsViewModel.kt
+++ b/sample/src/main/java/com/smileidentity/sample/viewmodel/JobsViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.smileidentity.SmileID
 import com.smileidentity.compose.components.ProcessingState
-import com.smileidentity.sample.repo.DataStoreRepository
+import com.smileidentity.sample.repo.DataStoreRepository.getAllJobs
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
@@ -26,7 +26,7 @@ data class JobsUiState(
 class JobsViewModel(isProduction: Boolean) : ViewModel() {
     private val _uiState = MutableStateFlow(JobsUiState())
     val uiState = _uiState.asStateFlow()
-    val jobs = DataStoreRepository.getJobs(SmileID.config.partnerId, isProduction).catch {
+    val jobs = getAllJobs(SmileID.config.partnerId, isProduction).catch {
         Timber.e(it)
         _uiState.update { it.copy(processingState = ProcessingState.Error) }
     }.onEach {

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -18,6 +18,11 @@
     <string name="jobs">Jobs</string>
     <string name="jobs_clear_jobs_icon_tooltip">Clear Job History</string>
     <string name="jobs_no_jobs_found">No jobs found</string>
+    <string name="jobs_detail_user_id_label">User ID</string>
+    <string name="jobs_detail_job_id_label">Job ID</string>
+    <string name="jobs_detail_smile_job_id_label">Smile Job ID</string>
+    <string name="jobs_detail_result_code_label">Result Code</string>
+    <string name="jobs_detail_code_label">Code</string>
 
     <!--  Resources Screen  -->
     <string name="resources">Resources</string>


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/10157/remove-polling-for-submission-of-images

## Summary

Sets up a background jobs poller in MainScreenViewModel, which collects DataStore Flow updates, and launches the poll Flow from the SDK. After the job is complete (either by actually being complete or timing out), polling is halted. 

## Known Issues

There is no retry mechanism currently for jobs that have timed out

## Screenshot
Updated UI:
<img width="426" alt="image" src="https://github.com/smileidentity/android/assets/6133201/be94876c-538b-43b2-bc73-f842bd4946d8">