### PR TITLE
Actions updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,9 @@
 name: Lint Build and Test
 on:
   pull_request:
+  merge_group:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/release_sdk.yaml
+++ b/.github/workflows/release_sdk.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       # https://github.com/actions/checkout/issues/766

--- a/lib/VERSION
+++ b/lib/VERSION
@@ -1,1 +1,1 @@
-10.0.0-beta05-SNAPSHOT
+10.0.0-beta06-SNAPSHOT


### PR DESCRIPTION
## Summary

- Support Merge Queue
- Increase release pipeline timeout (https://github.com/smileidentity/android/actions/runs/5648192010/job/15299881137): sometimes it takes longer than 10m for the Maven repository to close and release