### PR TITLE
Add Compose Compiler Metrics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,9 @@ uploadKeystorePassword=<The password for the upload keystore>
 - The linter enforces a maximum line length of 100 characters. Please try to keep lines under this
   length. However, if it is not possible (i.e. a long resource name), you can disable the check for
   the line by adding `// ktlint-disable max-line-length` to the end of the line
+- You can obtain Compose Compiler metrics (i.e. to debug performance or recomposition issues) by
+  running `./gradlew clean assemble -PenableComposeCompilerReports=true`. The reports will be
+  saved to `lib/build/compose-metrics` and `sample/build/compose-metrics`
 - It is recommended to set up a pre-commit hook (ktLint - formatting, lint - Composable lints). To
   do so, add the following to `.git/hooks/pre-commit`:
   ```

--- a/lib/lib.gradle.kts
+++ b/lib/lib.gradle.kts
@@ -61,6 +61,15 @@ android {
             // without having to add the opt-in annotation to every usage. The annotation's purpose
             // is primarily for consumers of the SDK to use, not for us.
             freeCompilerArgs += "-opt-in=com.smileidentity.SmileIDOptIn"
+            if (project.hasProperty("enableComposeCompilerReports")) {
+                val outputDir = project.buildDir.path + "/compose-reports"
+                freeCompilerArgs += listOf(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$outputDir",
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$outputDir",
+                )
+            }
         }
     }
 

--- a/sample/sample.gradle.kts
+++ b/sample/sample.gradle.kts
@@ -66,6 +66,15 @@ android {
             // without having to add the opt-in annotation to every usage. The annotation's purpose
             // is primarily for consumers of the SDK to use, not for us.
             freeCompilerArgs += "-opt-in=com.smileidentity.SmileIDOptIn"
+            if (project.hasProperty("enableComposeCompilerReports")) {
+                val outputDir = project.buildDir.path + "/compose-reports"
+                freeCompilerArgs += listOf(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$outputDir",
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$outputDir",
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds the ability to generate compose compiler metrics using the `enableComposeCompilerReports` Gradle Property (e.g. `./gradlew clean assemble -PenableComposeCompilerReports=true`)

Outputs saved to `<module dir>/build/compose-metrics`