### PR TITLE
Refactor Document Capture to be re-usable

### DIFF
--- a/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
+++ b/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
@@ -121,9 +121,9 @@ fun SmileID.SmartSelfieAuthentication(
  * [Docs](https://docs.usesmileid.com/products/for-individuals-kyc/document-verification)
  *
  * @param idType The type of ID to be captured
- * @param idAspectRatio The aspect ratio of the ID to be captured. If not specified, it will be
- * inferred from the enforced ID type (if provided). If neither are provided, the aspect ratio will
- * attempt to be inferred from the device's camera. If that fails, it will default to 1.6.
+ * @param idAspectRatio The aspect ratio of the ID to be captured. If not specified, the aspect
+ * ratio will attempt to be inferred from the device's camera. If that fails, it will default to a
+ * standard size of ~1.6
  * @param captureBothSides Whether to capture both sides of the ID or not. Otherwise, only the front
  * side will be captured.
  * @param bypassSelfieCaptureWithFile If provided, the user will not be prompted to take a selfie
@@ -147,8 +147,7 @@ fun SmileID.SmartSelfieAuthentication(
 @Composable
 fun SmileID.DocumentVerification(
     idType: Document,
-    // todo: make this optional again
-    idAspectRatio: Float = idType.aspectRatio,
+    idAspectRatio: Float? = null,
     captureBothSides: Boolean = false,
     bypassSelfieCaptureWithFile: File? = null,
     userId: String = rememberSaveable { randomUserId() },

--- a/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
+++ b/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
@@ -147,7 +147,8 @@ fun SmileID.SmartSelfieAuthentication(
 @Composable
 fun SmileID.DocumentVerification(
     idType: Document,
-    idAspectRatio: Float? = idType.aspectRatio,
+    // todo: make this optional again
+    idAspectRatio: Float = idType.aspectRatio,
     captureBothSides: Boolean = false,
     bypassSelfieCaptureWithFile: File? = null,
     userId: String = rememberSaveable { randomUserId() },

--- a/lib/src/main/java/com/smileidentity/compose/components/AnnotatedStringResource.kt
+++ b/lib/src/main/java/com/smileidentity/compose/components/AnnotatedStringResource.kt
@@ -1,0 +1,38 @@
+package com.smileidentity.compose.components
+
+import android.text.Annotation
+import android.text.SpannedString
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.core.text.getSpans
+import com.smileidentity.util.SpanFormatter
+
+@Composable
+@ReadOnlyComposable
+internal fun annotatedStringResource(
+    @StringRes id: Int,
+    vararg formatArgs: Any,
+    spanStyles: (Annotation) -> SpanStyle? = { null },
+): AnnotatedString {
+    // Using resources.getText() instead of stringResource() in order to preserve Spans
+    val resources = LocalContext.current.resources
+    val spannedString = SpanFormatter.format(SpannedString(resources.getText(id)), *formatArgs)
+    val resultBuilder = AnnotatedString.Builder()
+    resultBuilder.append(spannedString.toString())
+    spannedString.getSpans<Annotation>().forEach { annotation ->
+        val spanStart = spannedString.getSpanStart(annotation)
+        val spanEnd = spannedString.getSpanEnd(annotation)
+        resultBuilder.addStringAnnotation(
+            tag = annotation.key,
+            annotation = annotation.value,
+            start = spanStart,
+            end = spanEnd,
+        )
+        spanStyles(annotation)?.let { resultBuilder.addStyle(it, spanStart, spanEnd) }
+    }
+    return resultBuilder.toAnnotatedString()
+}

--- a/lib/src/main/java/com/smileidentity/compose/consent/ConsentScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/ConsentScreen.kt
@@ -30,9 +30,9 @@ import androidx.compose.ui.unit.dp
 import com.smileidentity.R
 import com.smileidentity.compose.components.BottomPinnedColumn
 import com.smileidentity.compose.components.SmileIDAttribution
+import com.smileidentity.compose.components.annotatedStringResource
 import com.smileidentity.compose.preview.Preview
 import com.smileidentity.compose.preview.SmilePreviews
-import com.smileidentity.util.annotatedStringResource
 import java.net.URL
 
 @Composable

--- a/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -149,6 +150,7 @@ internal fun DocumentCaptureScreen(
             subtitleText = captureSubtitleText,
             idAspectRatio = idAspectRatio,
             areEdgesDetected = uiState.areEdgesDetected,
+            showCaptureInProgress = uiState.showCaptureInProgress,
             onCaptureClicked = viewModel::captureDocument,
             modifier = modifier,
         )
@@ -161,6 +163,7 @@ private fun CaptureScreenContent(
     subtitleText: String,
     idAspectRatio: Float?,
     areEdgesDetected: Boolean,
+    showCaptureInProgress: Boolean,
     onCaptureClicked: (CameraState) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -214,20 +217,25 @@ private fun CaptureScreenContent(
                 fontWeight = FontWeight.Bold,
             )
             Spacer(modifier = Modifier.height(8.dp))
-            CaptureDocumentButton { onCaptureClicked(cameraState) }
+            val captureButtonSize = Modifier.size(64.dp)
+            if (showCaptureInProgress) {
+                CircularProgressIndicator(modifier = captureButtonSize)
+            } else {
+                CaptureDocumentButton(captureButtonSize) { onCaptureClicked(cameraState) }
+            }
         }
     }
 }
 
 @Composable
 private fun CaptureDocumentButton(
+    modifier: Modifier = Modifier,
     onCaptureClicked: () -> Unit,
 ) {
     Image(
         painter = painterResource(id = R.drawable.si_camera_capture),
         contentDescription = "smile_camera_capture",
-        modifier = Modifier
-            .size(70.dp)
+        modifier = modifier
             .clickable(onClick = onCaptureClicked),
     )
 }
@@ -241,6 +249,7 @@ private fun CaptureScreenContentPreview() {
             subtitleText = "Make sure all corners are visible and there is no glare",
             idAspectRatio = 1.59f,
             areEdgesDetected = true,
+            showCaptureInProgress = false,
             onCaptureClicked = {},
         )
     }

--- a/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureScreen.kt
@@ -75,7 +75,7 @@ internal fun DocumentCaptureScreen(
     instructionsSubtitleText: String,
     captureTitleText: String,
     captureSubtitleText: String,
-    idAspectRatio: Float,
+    idAspectRatio: Float?,
     onConfirm: (File) -> Unit,
     onError: (Throwable) -> Unit,
     modifier: Modifier = Modifier,
@@ -159,7 +159,7 @@ internal fun DocumentCaptureScreen(
 private fun CaptureScreenContent(
     titleText: String,
     subtitleText: String,
-    idAspectRatio: Float,
+    idAspectRatio: Float?,
     areEdgesDetected: Boolean,
     onCaptureClicked: (CameraState) -> Unit,
     modifier: Modifier = Modifier,

--- a/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureScreen.kt
@@ -45,7 +45,7 @@ import com.smileidentity.compose.components.ImageCaptureConfirmationDialog
 import com.smileidentity.compose.preview.Preview
 import com.smileidentity.compose.preview.SmilePreviews
 import com.smileidentity.util.generateFileFromUri
-import com.smileidentity.util.isImageAtLeast
+import com.smileidentity.util.isValidDocumentImage
 import com.smileidentity.util.toast
 import com.smileidentity.viewmodel.document.DocumentCaptureViewModel
 import com.smileidentity.viewmodel.viewModelFactory
@@ -95,7 +95,7 @@ internal fun DocumentCaptureScreen(
                 context.toast(R.string.si_doc_v_capture_error_subtitle)
                 return@rememberLauncherForActivityResult
             }
-            if (isImageAtLeast(context, uri, width = 1920, height = 1080)) {
+            if (isValidDocumentImage(context, uri)) {
                 val selectedPhotoFile = generateFileFromUri(uri = uri, context = context)
                 viewModel.onPhotoSelectedFromGallery(selectedPhotoFile)
             } else {

--- a/lib/src/main/java/com/smileidentity/compose/document/DocumentShapedBoundingBox.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/DocumentShapedBoundingBox.kt
@@ -25,18 +25,18 @@ val DOCUMENT_BOUNDING_BOX_RADIUS = CornerRadius(30f, 30f)
  * has an outline which changes color depending on edge detection algorithm
  *
  * @param aspectRatio The aspect ratio of the document, used to calculate the height of the view.
- * @param modifier The modifier to be applied to the indicator.
- * @param strokeWidth The width of the progress indicator stroke.
  * @param areEdgesDetected A boolean flag that is updated when document edges are within bounding
  * box edges
+ * @param modifier The modifier to be applied to the indicator.
+ * @param strokeWidth The width of the progress indicator stroke.
  * @param backgroundColor The color of the background that is drawn around the document shape.
  */
 @Composable
 fun DocumentShapedBoundingBox(
     aspectRatio: Float?,
+    areEdgesDetected: Boolean,
     modifier: Modifier = Modifier,
     strokeWidth: Dp = ProgressIndicatorDefaults.CircularStrokeWidth,
-    areEdgesDetected: Boolean = false,
     backgroundColor: Color = MaterialTheme.colorScheme.scrim,
 ) {
     val strokeColor = if (areEdgesDetected) MaterialTheme.colorScheme.tertiary else Color.Gray
@@ -87,6 +87,9 @@ fun DocumentShapedBoundingBox(
 @Composable
 private fun DocumentShapedBoundingBoxPreview() {
     Preview {
-        DocumentShapedBoundingBox(aspectRatio = 16f / 9f)
+        DocumentShapedBoundingBox(
+            areEdgesDetected = true,
+            aspectRatio = 16f / 9f,
+        )
     }
 }

--- a/lib/src/main/java/com/smileidentity/compose/document/DocumentShapedBoundingBox.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/DocumentShapedBoundingBox.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.unit.Dp
 import com.smileidentity.compose.preview.Preview
 import com.smileidentity.compose.preview.SmilePreviews
 
-const val DEFAULT_DOCUMENT_ASPECT_RATIO = 3.56f
+const val DEFAULT_DOCUMENT_ASPECT_RATIO = 3.375f / 2.125f
 const val DOCUMENT_BOUNDING_BOX_MARGINS = 30f
 val DOCUMENT_BOUNDING_BOX_RADIUS = CornerRadius(30f, 30f)
 

--- a/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
@@ -52,10 +52,9 @@ internal fun OrchestratedDocumentVerificationScreen(
     onResult: SmileIDCallback<DocumentVerificationResult> = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val currentStep = uiState.currentStep
-
-    when (currentStep) {
+    when (val currentStep = uiState.currentStep) {
         DocumentCaptureFlow.FrontDocumentCapture -> DocumentCaptureScreen(
+            side = DocumentCaptureSide.Front,
             showInstructions = showInstructions,
             showAttribution = showAttribution,
             allowGallerySelection = allowGalleryUpload,
@@ -70,11 +69,12 @@ internal fun OrchestratedDocumentVerificationScreen(
                 id = R.string.si_doc_v_capture_instructions_subtitle,
             ),
             idAspectRatio = idAspectRatio,
-            onConfirm = viewModel::onDocumentFrontConfirmed,
-            onError = { viewModel.onDocumentRejected(isBackSide = false) },
+            onConfirm = viewModel::onDocumentFrontCaptureSuccess,
+            onError = viewModel::onError,
         )
 
         DocumentCaptureFlow.BackDocumentCapture -> DocumentCaptureScreen(
+            side = DocumentCaptureSide.Back,
             showInstructions = showInstructions,
             showAttribution = showAttribution,
             allowGallerySelection = allowGalleryUpload,
@@ -89,8 +89,8 @@ internal fun OrchestratedDocumentVerificationScreen(
                 id = R.string.si_doc_v_capture_instructions_subtitle,
             ),
             idAspectRatio = idAspectRatio,
-            onConfirm = viewModel::onDocumentBackConfirmed,
-            onError = { viewModel.onDocumentRejected(isBackSide = true) },
+            onConfirm = viewModel::onDocumentBackCaptureSuccess,
+            onError = viewModel::onError,
         )
 
         DocumentCaptureFlow.SelfieCapture -> OrchestratedSelfieCaptureScreen(
@@ -103,7 +103,7 @@ internal fun OrchestratedDocumentVerificationScreen(
             skipApiSubmission = true,
         ) {
             when (it) {
-                is SmileIDResult.Error -> viewModel.onSelfieCaptureError(it)
+                is SmileIDResult.Error -> viewModel.onError(it.throwable)
                 is SmileIDResult.Success -> viewModel.onSelfieCaptureSuccess(it)
             }
         }
@@ -126,7 +126,7 @@ internal fun OrchestratedDocumentVerificationScreen(
             ),
             onContinue = { viewModel.onFinished(onResult) },
             retryButtonText = stringResource(R.string.si_smart_selfie_processing_retry_button),
-            onRetry = { viewModel.onRetry(captureBothSides) },
+            onRetry = viewModel::onRetry,
             closeButtonText = stringResource(R.string.si_smart_selfie_processing_close_button),
             onClose = { viewModel.onFinished(onResult) },
         )

--- a/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
@@ -1,27 +1,13 @@
 package com.smileidentity.compose.document
 
-import android.graphics.BitmapFactory
-import android.net.Uri
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
-import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageOnly
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.smileidentity.R
-import com.smileidentity.SmileIDCrashReporting
-import com.smileidentity.compose.components.ImageCaptureConfirmationDialog
 import com.smileidentity.compose.components.ProcessingScreen
 import com.smileidentity.compose.selfie.OrchestratedSelfieCaptureScreen
 import com.smileidentity.models.Document
@@ -29,14 +15,10 @@ import com.smileidentity.models.DocumentCaptureFlow
 import com.smileidentity.results.DocumentVerificationResult
 import com.smileidentity.results.SmileIDCallback
 import com.smileidentity.results.SmileIDResult
-import com.smileidentity.util.generateFileFromUri
-import com.smileidentity.util.isImageAtLeast
 import com.smileidentity.util.randomJobId
 import com.smileidentity.util.randomUserId
-import com.smileidentity.util.toast
 import com.smileidentity.viewmodel.document.OrchestratedDocumentViewModel
 import com.smileidentity.viewmodel.viewModelFactory
-import timber.log.Timber
 import java.io.File
 
 /**
@@ -46,7 +28,8 @@ import java.io.File
 @Composable
 internal fun OrchestratedDocumentVerificationScreen(
     idType: Document,
-    idAspectRatio: Float? = idType.aspectRatio,
+    // todo: make this optional again
+    idAspectRatio: Float = idType.aspectRatio,
     captureBothSides: Boolean = false,
     bypassSelfieCaptureWithFile: File? = null,
     userId: String = rememberSaveable { randomUserId() },
@@ -61,42 +44,72 @@ internal fun OrchestratedDocumentVerificationScreen(
                 jobId = jobId,
                 idType = idType,
                 idAspectRatio = idAspectRatio,
+                captureBothSides = captureBothSides,
+                selfieFile = bypassSelfieCaptureWithFile,
             )
         },
     ),
     onResult: SmileIDCallback<DocumentVerificationResult> = {},
 ) {
-    val context = LocalContext.current
-    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
-    var acknowledgedInstructions by rememberSaveable { mutableStateOf(false) }
-    var shouldSelectFromGallery by rememberSaveable { mutableStateOf(false) }
-    var isFrontDocumentPhotoValid by rememberSaveable { mutableStateOf(false) }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val currentStep = uiState.currentStep
 
-    when (
-        val state = DocumentCaptureFlow.stateFrom(
-            acknowledgedInstructions = acknowledgedInstructions,
-            processingState = uiState.processingState,
-            shouldSelectFromGallery = shouldSelectFromGallery,
-            captureBothSides = captureBothSides,
-            isFrontDocumentPhotoValid = isFrontDocumentPhotoValid,
+    when (currentStep) {
+        DocumentCaptureFlow.FrontDocumentCapture -> DocumentCaptureScreen(
             showInstructions = showInstructions,
-            uiState = uiState,
-        )
-    ) {
-        DocumentCaptureFlow.ShowInstructions -> DocumentCaptureInstructionsScreen(
-            title = stringResource(R.string.si_doc_v_instruction_title),
-            subtitle = stringResource(id = R.string.si_verify_identity_instruction_subtitle),
             showAttribution = showAttribution,
-            allowPhotoFromGallery = allowGalleryUpload,
-            onInstructionsAcknowledgedTakePhoto = { acknowledgedInstructions = true },
-            onInstructionsAcknowledgedSelectFromGallery = {
-                acknowledgedInstructions = true
-                shouldSelectFromGallery = true
-            },
+            allowGallerySelection = allowGalleryUpload,
+            instructionsTitleText = stringResource(R.string.si_doc_v_instruction_title),
+            instructionsSubtitleText = stringResource(
+                id = R.string.si_verify_identity_instruction_subtitle,
+            ),
+            captureTitleText = stringResource(
+                id = R.string.si_doc_v_capture_instructions_front_title,
+            ),
+            captureSubtitleText = stringResource(
+                id = R.string.si_doc_v_capture_instructions_subtitle,
+            ),
+            idAspectRatio = idAspectRatio,
+            onConfirm = viewModel::onDocumentFrontConfirmed,
+            onError = { viewModel.onDocumentRejected(isBackSide = false) },
         )
+
+        DocumentCaptureFlow.BackDocumentCapture -> DocumentCaptureScreen(
+            showInstructions = showInstructions,
+            showAttribution = showAttribution,
+            allowGallerySelection = allowGalleryUpload,
+            instructionsTitleText = stringResource(R.string.si_doc_v_instruction_back_title),
+            instructionsSubtitleText = stringResource(
+                id = R.string.si_doc_v_instruction_back_subtitle,
+            ),
+            captureTitleText = stringResource(
+                id = R.string.si_doc_v_capture_instructions_back_title,
+            ),
+            captureSubtitleText = stringResource(
+                id = R.string.si_doc_v_capture_instructions_subtitle,
+            ),
+            idAspectRatio = idAspectRatio,
+            onConfirm = viewModel::onDocumentBackConfirmed,
+            onError = { viewModel.onDocumentRejected(isBackSide = true) },
+        )
+
+        DocumentCaptureFlow.SelfieCapture -> OrchestratedSelfieCaptureScreen(
+            userId = userId,
+            jobId = jobId,
+            isEnroll = false,
+            allowAgentMode = false,
+            showAttribution = showAttribution,
+            showInstructions = showInstructions,
+            skipApiSubmission = true,
+        ) {
+            when (it) {
+                is SmileIDResult.Error -> viewModel.onSelfieCaptureError(it)
+                is SmileIDResult.Success -> viewModel.onSelfieCaptureSuccess(it)
+            }
+        }
 
         is DocumentCaptureFlow.ProcessingScreen -> ProcessingScreen(
-            processingState = state.processingState,
+            processingState = currentStep.processingState,
             inProgressTitle = stringResource(R.string.si_doc_v_processing_title),
             inProgressSubtitle = stringResource(R.string.si_doc_v_processing_subtitle),
             inProgressIcon = painterResource(R.drawable.si_doc_v_processing_hero),
@@ -117,216 +130,5 @@ internal fun OrchestratedDocumentVerificationScreen(
             closeButtonText = stringResource(R.string.si_smart_selfie_processing_close_button),
             onClose = { viewModel.onFinished(onResult) },
         )
-
-        DocumentCaptureFlow.FrontDocumentCapture -> DocumentCaptureScreen(
-            userId = userId,
-            jobId = jobId,
-            idType = idType,
-            idAspectRatio = idAspectRatio,
-            titleText = stringResource(id = R.string.si_doc_v_capture_instructions_front_title),
-            subtitleText = stringResource(id = R.string.si_doc_v_capture_instructions_subtitle),
-            bypassSelfieCaptureWithFile = bypassSelfieCaptureWithFile,
-        )
-
-        DocumentCaptureFlow.FrontDocumentCaptureConfirmation -> ImageCaptureConfirmationDialog(
-            titleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_title),
-            subtitleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_subtitle),
-            painter = BitmapPainter(
-                BitmapFactory.decodeFile(uiState.frontDocumentImageToConfirm!!.absolutePath)
-                    .asImageBitmap(),
-            ),
-            confirmButtonText = stringResource(
-                id = R.string.si_doc_v_confirmation_dialog_confirm_button,
-            ),
-            onConfirm = {
-                isFrontDocumentPhotoValid = true
-            },
-            retakeButtonText = stringResource(
-                id = R.string.si_doc_v_confirmation_dialog_retake_button,
-            ),
-            onRetake = {
-                viewModel.onDocumentRejected(isBackSide = true)
-                isFrontDocumentPhotoValid = false
-            },
-        )
-
-        DocumentCaptureFlow.BackDocumentCapture -> DocumentCaptureScreen(
-            userId = userId,
-            jobId = jobId,
-            idType = idType,
-            idAspectRatio = idAspectRatio,
-            titleText = stringResource(id = R.string.si_doc_v_capture_instructions_back_title),
-            subtitleText = stringResource(id = R.string.si_doc_v_capture_instructions_subtitle),
-            isBackSide = true,
-            bypassSelfieCaptureWithFile = bypassSelfieCaptureWithFile,
-        )
-
-        DocumentCaptureFlow.BackDocumentCaptureConfirmation -> ImageCaptureConfirmationDialog(
-            titleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_title),
-            subtitleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_subtitle),
-            painter = BitmapPainter(
-                BitmapFactory.decodeFile(uiState.backDocumentImageToConfirm!!.absolutePath)
-                    .asImageBitmap(),
-            ),
-            confirmButtonText = stringResource(
-                id = R.string.si_doc_v_confirmation_dialog_confirm_button,
-            ),
-            onConfirm = { viewModel.onDocumentConfirmed() },
-            retakeButtonText = stringResource(
-                id = R.string.si_doc_v_confirmation_dialog_retake_button,
-            ),
-            onRetake = { viewModel.onDocumentRejected(isBackSide = true) },
-        )
-
-        DocumentCaptureFlow.CameraOneSide -> DocumentCaptureScreen(
-            userId = userId,
-            jobId = jobId,
-            idType = idType,
-            idAspectRatio = idAspectRatio,
-            titleText = stringResource(id = R.string.si_doc_v_capture_instructions_front_title),
-            subtitleText = stringResource(id = R.string.si_doc_v_capture_instructions_subtitle),
-        )
-
-        DocumentCaptureFlow.CameraOneSideConfirmation -> {
-            ImageCaptureConfirmationDialog(
-                titleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_title),
-                subtitleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_subtitle),
-                painter = BitmapPainter(
-                    BitmapFactory.decodeFile(uiState.frontDocumentImageToConfirm!!.absolutePath)
-                        .asImageBitmap(),
-                ),
-                confirmButtonText = stringResource(
-                    id = R.string.si_doc_v_confirmation_dialog_confirm_button,
-                ),
-                onConfirm = { viewModel.onDocumentConfirmed() },
-                retakeButtonText = stringResource(
-                    id = R.string.si_doc_v_confirmation_dialog_retake_button,
-                ),
-                onRetake = { viewModel.onDocumentRejected(isBackSide = false) },
-            )
-        }
-
-        DocumentCaptureFlow.FrontDocumentGallerySelection -> PhotoPickerScreen {
-            viewModel.saveFileFromGallerySelection(generateFileFromUri(uri = it, context = context))
-        }
-
-        DocumentCaptureFlow.FrontDocumentGalleryConfirmation -> ImageCaptureConfirmationDialog(
-            titleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_title),
-            subtitleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_subtitle),
-            painter = BitmapPainter(
-                BitmapFactory.decodeFile(uiState.frontDocumentImageToConfirm!!.absolutePath)
-                    .asImageBitmap(),
-            ),
-            confirmButtonText = stringResource(
-                id = R.string.si_doc_v_confirmation_dialog_confirm_button,
-            ),
-            onConfirm = {
-                isFrontDocumentPhotoValid = true
-            },
-            retakeButtonText = stringResource(
-                id = R.string.si_doc_v_confirmation_dialog_retake_button,
-            ),
-            onRetake = {
-                viewModel.onDocumentRejected(isBackSide = false)
-                isFrontDocumentPhotoValid = false
-            },
-        )
-
-        DocumentCaptureFlow.BackDocumentGallerySelection -> PhotoPickerScreen {
-            viewModel.saveFileFromGallerySelection(
-                generateFileFromUri(uri = it, context = context),
-                isBackSide = true,
-            )
-        }
-
-        DocumentCaptureFlow.BackDocumentGalleryConfirmation -> ImageCaptureConfirmationDialog(
-            titleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_title),
-            subtitleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_subtitle),
-            painter = BitmapPainter(
-                BitmapFactory.decodeFile(uiState.backDocumentImageToConfirm!!.absolutePath)
-                    .asImageBitmap(),
-            ),
-            confirmButtonText = stringResource(
-                id = R.string.si_doc_v_confirmation_dialog_confirm_button,
-            ),
-            onConfirm = { viewModel.onDocumentConfirmed() },
-            retakeButtonText = stringResource(
-                id = R.string.si_doc_v_confirmation_dialog_retake_button,
-            ),
-            onRetake = { viewModel.onDocumentRejected(true) },
-        )
-
-        DocumentCaptureFlow.GalleryOneSide -> PhotoPickerScreen {
-            viewModel.saveFileFromGallerySelection(generateFileFromUri(uri = it, context = context))
-            isFrontDocumentPhotoValid = true
-        }
-
-        DocumentCaptureFlow.GalleryOneSideConfirmation -> ImageCaptureConfirmationDialog(
-            titleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_title),
-            subtitleText = stringResource(id = R.string.si_doc_v_confirmation_dialog_subtitle),
-            painter = BitmapPainter(
-                BitmapFactory.decodeFile(uiState.frontDocumentImageToConfirm!!.absolutePath)
-                    .asImageBitmap(),
-            ),
-            confirmButtonText = stringResource(
-                id = R.string.si_doc_v_confirmation_dialog_confirm_button,
-            ),
-            onConfirm = { viewModel.onDocumentConfirmed() },
-            retakeButtonText = stringResource(
-                id = R.string.si_doc_v_confirmation_dialog_retake_button,
-            ),
-            onRetake = { viewModel.onDocumentRejected(isBackSide = false) },
-        )
-
-        DocumentCaptureFlow.SelfieCapture -> OrchestratedSelfieCaptureScreen(
-            userId = userId,
-            jobId = jobId,
-            isEnroll = false,
-            allowAgentMode = false,
-            showAttribution = showAttribution,
-            showInstructions = showInstructions,
-            skipApiSubmission = true,
-        ) {
-            when (it) {
-                is SmileIDResult.Error -> viewModel.onSelfieCaptureError(it)
-                is SmileIDResult.Success -> viewModel.onSelfieCaptureSuccess(it)
-            }
-        }
-
-        DocumentCaptureFlow.Unknown -> {
-            SmileIDCrashReporting.hub.captureException(
-                IllegalStateException(
-                    "Document Verification option not available \n" +
-                        " values passed are : " +
-                        " acknowledgedInstructions $acknowledgedInstructions " +
-                        " processingState $uiState.processingState " +
-                        " uiState $uiState " +
-                        " shouldSelectFromGallery $shouldSelectFromGallery " +
-                        " captureBothSides $captureBothSides " +
-                        " isFrontDocumentPhotoValid $isFrontDocumentPhotoValid ",
-                ),
-            )
-        }
-    }
-}
-
-@Composable
-fun PhotoPickerScreen(onPhotoSelected: (documentPhoto: Uri) -> Unit) {
-    val context = LocalContext.current
-    val photoPickerLauncher = rememberLauncherForActivityResult(
-        contract = PickVisualMedia(),
-        onResult = { uri ->
-            Timber.v("selectedUri: $uri")
-            uri?.let {
-                if (isImageAtLeast(context, uri, width = 1920, height = 1080)) {
-                    onPhotoSelected(uri)
-                } else {
-                    context.toast(R.string.si_doc_v_validation_image_too_small)
-                }
-            }
-        },
-    )
-    LaunchedEffect(Unit) {
-        photoPickerLauncher.launch(PickVisualMediaRequest(ImageOnly))
     }
 }

--- a/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
@@ -28,8 +28,7 @@ import java.io.File
 @Composable
 internal fun OrchestratedDocumentVerificationScreen(
     idType: Document,
-    // todo: make this optional again
-    idAspectRatio: Float = idType.aspectRatio,
+    idAspectRatio: Float? = null,
     captureBothSides: Boolean = false,
     bypassSelfieCaptureWithFile: File? = null,
     userId: String = rememberSaveable { randomUserId() },
@@ -43,7 +42,6 @@ internal fun OrchestratedDocumentVerificationScreen(
                 userId = userId,
                 jobId = jobId,
                 idType = idType,
-                idAspectRatio = idAspectRatio,
                 captureBothSides = captureBothSides,
                 selfieFile = bypassSelfieCaptureWithFile,
             )

--- a/lib/src/main/java/com/smileidentity/fragment/DocumentVerificationFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/DocumentVerificationFragment.kt
@@ -72,7 +72,8 @@ class DocumentVerificationFragment : Fragment() {
             showAttribution: Boolean = true,
             allowGalleryUpload: Boolean = false,
             idType: Document,
-            idAspectRatio: Float? = idType.aspectRatio,
+            // todo: make this optional again
+            idAspectRatio: Float = idType.aspectRatio,
             captureBothSides: Boolean = false,
             bypassSelfieCaptureWithFile: File? = null,
         ) = DocumentVerificationFragment().apply {
@@ -145,7 +146,9 @@ private var Bundle.idType: Document
     set(value) = putParcelable(KEY_ID_TYPE, value)
 
 private const val KEY_ID_ASPECT_RATIO = "idAspectRatio"
-private var Bundle.idAspectRatio: Float?
+
+// todo: make this optional again
+private var Bundle.idAspectRatio: Float
     get() = getFloat(KEY_ID_ASPECT_RATIO)
     set(value) = putFloat(KEY_ID_ASPECT_RATIO, value ?: -1f)
 

--- a/lib/src/main/java/com/smileidentity/fragment/DocumentVerificationFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/DocumentVerificationFragment.kt
@@ -72,8 +72,7 @@ class DocumentVerificationFragment : Fragment() {
             showAttribution: Boolean = true,
             allowGalleryUpload: Boolean = false,
             idType: Document,
-            // todo: make this optional again
-            idAspectRatio: Float = idType.aspectRatio,
+            idAspectRatio: Float? = null,
             captureBothSides: Boolean = false,
             bypassSelfieCaptureWithFile: File? = null,
         ) = DocumentVerificationFragment().apply {
@@ -83,7 +82,7 @@ class DocumentVerificationFragment : Fragment() {
                 this.showAttribution = showAttribution
                 this.allowGalleryUpload = allowGalleryUpload
                 this.idType = idType
-                this.idAspectRatio = idAspectRatio
+                this.idAspectRatio = idAspectRatio ?: -1f
                 this.captureBothSides = captureBothSides
                 this.bypassSelfieCaptureWithFile = bypassSelfieCaptureWithFile
             }
@@ -103,13 +102,14 @@ class DocumentVerificationFragment : Fragment() {
         setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
         val args = requireArguments()
         setContent {
+            val aspectRatio = args.idAspectRatio
             SmileID.DocumentVerification(
                 userId = args.userId,
                 jobId = args.jobId,
                 showAttribution = args.showAttribution,
                 allowGalleryUpload = args.allowGalleryUpload,
                 idType = args.idType,
-                idAspectRatio = args.idAspectRatio,
+                idAspectRatio = if (aspectRatio > 0) aspectRatio else null,
                 captureBothSides = args.captureBothSides,
                 bypassSelfieCaptureWithFile = args.bypassSelfieCaptureWithFile,
                 onResult = {
@@ -147,10 +147,9 @@ private var Bundle.idType: Document
 
 private const val KEY_ID_ASPECT_RATIO = "idAspectRatio"
 
-// todo: make this optional again
 private var Bundle.idAspectRatio: Float
     get() = getFloat(KEY_ID_ASPECT_RATIO)
-    set(value) = putFloat(KEY_ID_ASPECT_RATIO, value ?: -1f)
+    set(value) = putFloat(KEY_ID_ASPECT_RATIO, value)
 
 private const val KEY_CAPTURE_BOTH_SIDES = "captureBothSides"
 private var Bundle.captureBothSides: Boolean

--- a/lib/src/main/java/com/smileidentity/models/Document.kt
+++ b/lib/src/main/java/com/smileidentity/models/Document.kt
@@ -1,19 +1,15 @@
 package com.smileidentity.models
 
 import android.os.Parcelable
-import androidx.annotation.FloatRange
 import kotlinx.parcelize.Parcelize
 
 /**
  * Represents a document type that can be used for Document Verification.
  * @param countryCode The ISO 3166-1 alpha-3 country code of the document
  * @param documentType The document type
- * @param aspectRatio The aspect ratio of the document. Defaults to 3.375f / 2.125f (1.59), which is
- * the standard ID Card and Credit Card size
  */
 @Parcelize
 data class Document(
     val countryCode: String,
     val documentType: String,
-    @FloatRange(from = 0.0) val aspectRatio: Float = 3.375f / 2.125f,
 ) : Parcelable

--- a/lib/src/main/java/com/smileidentity/models/DocumentCaptureFlow.kt
+++ b/lib/src/main/java/com/smileidentity/models/DocumentCaptureFlow.kt
@@ -1,121 +1,18 @@
 package com.smileidentity.models
 
 import com.smileidentity.compose.components.ProcessingState
-import com.smileidentity.viewmodel.document.OrchestratedDocumentUiState
 
 /**
  * Handles the navigation logic for the document orchestration screen,
  * depending on partner config and ui state
  */
-internal sealed class DocumentCaptureFlow {
+internal sealed interface DocumentCaptureFlow {
 
-    object ShowInstructions : DocumentCaptureFlow()
+    object FrontDocumentCapture : DocumentCaptureFlow
+    object BackDocumentCapture : DocumentCaptureFlow
 
+    object SelfieCapture : DocumentCaptureFlow
     data class ProcessingScreen(
         val processingState: ProcessingState,
-    ) : DocumentCaptureFlow()
-
-    object GalleryOneSide : DocumentCaptureFlow()
-
-    object GalleryOneSideConfirmation : DocumentCaptureFlow()
-
-    object FrontDocumentGallerySelection : DocumentCaptureFlow()
-
-    object FrontDocumentGalleryConfirmation : DocumentCaptureFlow()
-
-    object BackDocumentGallerySelection : DocumentCaptureFlow()
-
-    object BackDocumentGalleryConfirmation : DocumentCaptureFlow()
-
-    object CameraOneSide : DocumentCaptureFlow()
-
-    object CameraOneSideConfirmation : DocumentCaptureFlow()
-
-    object FrontDocumentCapture : DocumentCaptureFlow()
-
-    object BackDocumentCapture : DocumentCaptureFlow()
-
-    object FrontDocumentCaptureConfirmation : DocumentCaptureFlow()
-
-    object BackDocumentCaptureConfirmation : DocumentCaptureFlow()
-
-    object SelfieCapture : DocumentCaptureFlow()
-
-    object Unknown : DocumentCaptureFlow()
-
-    companion object {
-        fun stateFrom(
-            acknowledgedInstructions: Boolean,
-            processingState: ProcessingState?,
-            uiState: OrchestratedDocumentUiState?,
-            shouldSelectFromGallery: Boolean,
-            captureBothSides: Boolean,
-            isFrontDocumentPhotoValid: Boolean,
-            showInstructions: Boolean,
-        ): DocumentCaptureFlow {
-            val selectGalleryOneSide =
-                shouldSelectFromGallery && !captureBothSides &&
-                    uiState?.frontDocumentImageToConfirm == null
-            val selectGalleryOneSideConfirmation =
-                shouldSelectFromGallery && !captureBothSides &&
-                    uiState?.frontDocumentImageToConfirm != null
-
-            val selectGalleryTwoSides =
-                shouldSelectFromGallery && captureBothSides &&
-                    uiState?.frontDocumentImageToConfirm == null
-            val selectGalleryTwoSidesConfirmation =
-                shouldSelectFromGallery && captureBothSides &&
-                    !isFrontDocumentPhotoValid && uiState?.frontDocumentImageToConfirm != null
-
-            val selectGalleryTwoSidesBack =
-                shouldSelectFromGallery && captureBothSides &&
-                    isFrontDocumentPhotoValid && uiState?.backDocumentImageToConfirm == null
-
-            val selectGalleryTwoSidesBackConfirmation =
-                shouldSelectFromGallery && captureBothSides &&
-                    isFrontDocumentPhotoValid && uiState?.backDocumentImageToConfirm != null
-
-            val captureOneSideCamera =
-                !shouldSelectFromGallery && !captureBothSides &&
-                    uiState?.frontDocumentImageToConfirm == null
-            val captureOneSideCameraConfirmation =
-                !shouldSelectFromGallery && !captureBothSides &&
-                    uiState?.frontDocumentImageToConfirm != null
-
-            val captureTwoSidesCamera =
-                !shouldSelectFromGallery && captureBothSides &&
-                    uiState?.frontDocumentImageToConfirm == null
-            val captureTwoSidesCameraConfirmation =
-                !shouldSelectFromGallery && captureBothSides &&
-                    !isFrontDocumentPhotoValid && uiState?.frontDocumentImageToConfirm != null
-
-            val captureTwoSidesCameraBack =
-                !shouldSelectFromGallery && captureBothSides &&
-                    isFrontDocumentPhotoValid && uiState?.backDocumentImageToConfirm == null
-            val captureTwoSidesCameraBackConfirmation =
-                !shouldSelectFromGallery && captureBothSides &&
-                    isFrontDocumentPhotoValid && uiState?.backDocumentImageToConfirm != null
-
-            val showSelfieCapture = uiState?.showSelfieCapture ?: false
-
-            return when {
-                showInstructions && !acknowledgedInstructions -> ShowInstructions
-                processingState != null -> ProcessingScreen(processingState = processingState)
-                showSelfieCapture -> SelfieCapture
-                selectGalleryOneSide -> GalleryOneSide
-                selectGalleryOneSideConfirmation -> GalleryOneSideConfirmation
-                selectGalleryTwoSides -> FrontDocumentGallerySelection
-                selectGalleryTwoSidesBack -> BackDocumentGallerySelection
-                selectGalleryTwoSidesConfirmation -> FrontDocumentGalleryConfirmation
-                selectGalleryTwoSidesBackConfirmation -> BackDocumentGalleryConfirmation
-                captureOneSideCamera -> CameraOneSide
-                captureOneSideCameraConfirmation -> CameraOneSideConfirmation
-                captureTwoSidesCamera -> FrontDocumentCapture
-                captureTwoSidesCameraConfirmation -> FrontDocumentCaptureConfirmation
-                captureTwoSidesCameraBack -> BackDocumentCapture
-                captureTwoSidesCameraBackConfirmation -> BackDocumentCaptureConfirmation
-                else -> Unknown
-            }
-        }
-    }
+    ) : DocumentCaptureFlow
 }

--- a/lib/src/main/java/com/smileidentity/util/Util.kt
+++ b/lib/src/main/java/com/smileidentity/util/Util.kt
@@ -17,19 +17,12 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import android.os.Bundle
 import android.os.Parcelable
-import android.text.Annotation
-import android.text.SpannedString
 import android.util.Size
 import android.widget.Toast
 import androidx.annotation.IntRange
 import androidx.annotation.StringRes
 import androidx.camera.core.impl.utils.Exif
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
 import androidx.core.graphics.scale
-import androidx.core.text.getSpans
 import androidx.exifinterface.media.ExifInterface
 import com.google.mlkit.vision.common.InputImage
 import com.smileidentity.SmileID
@@ -41,31 +34,6 @@ import retrofit2.HttpException
 import timber.log.Timber
 import java.io.File
 import java.io.Serializable
-
-@Composable
-internal fun annotatedStringResource(
-    @StringRes id: Int,
-    vararg formatArgs: Any,
-    spanStyles: (Annotation) -> SpanStyle? = { null },
-): AnnotatedString {
-    // Using resources.getText() instead of stringResource() in order to preserve Spans
-    val resources = LocalContext.current.resources
-    val spannedString = SpanFormatter.format(SpannedString(resources.getText(id)), *formatArgs)
-    val resultBuilder = AnnotatedString.Builder()
-    resultBuilder.append(spannedString.toString())
-    spannedString.getSpans<Annotation>().forEach { annotation ->
-        val spanStart = spannedString.getSpanStart(annotation)
-        val spanEnd = spannedString.getSpanEnd(annotation)
-        resultBuilder.addStringAnnotation(
-            tag = annotation.key,
-            annotation = annotation.value,
-            start = spanStart,
-            end = spanEnd,
-        )
-        spanStyles(annotation)?.let { resultBuilder.addStyle(it, spanStart, spanEnd) }
-    }
-    return resultBuilder.toAnnotatedString()
-}
 
 internal fun Context.toast(@StringRes message: Int) {
     Toast.makeText(this, message, Toast.LENGTH_LONG).show()

--- a/lib/src/main/java/com/smileidentity/util/Util.kt
+++ b/lib/src/main/java/com/smileidentity/util/Util.kt
@@ -67,6 +67,11 @@ fun isImageAtLeast(
     return (imageHeight >= (height ?: 0)) && (imageWidth >= (width ?: 0))
 }
 
+fun isValidDocumentImage(
+    context: Context,
+    uri: Uri?,
+) = isImageAtLeast(context, uri, width = 1920, height = 1080)
+
 /**
  * Post-processes the image stored in [bitmap] and saves to [file]. The image is scaled to
  * [maxOutputSize], but maintains the aspect ratio. The image can also converted to grayscale.

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
@@ -1,0 +1,98 @@
+package com.smileidentity.viewmodel.document
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.smileidentity.R
+import com.smileidentity.util.createDocumentFile
+import com.ujizin.camposer.state.CameraState
+import com.ujizin.camposer.state.ImageCaptureResult
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.io.File
+import kotlin.time.Duration.Companion.seconds
+
+data class DocumentCaptureUiState(
+    val acknowledgedInstructions: Boolean = false,
+    val areEdgesDetected: Boolean = false,
+    val showManualCaptureButton: Boolean = false,
+    val documentImageToConfirm: File? = null,
+    @StringRes val errorMessage: Int? = null,
+)
+
+class DocumentCaptureViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(DocumentCaptureUiState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        // Show manual capture after 10 seconds, using coroutine
+        viewModelScope.launch {
+            delay(10.seconds)
+            allowManualCapture()
+        }
+    }
+
+    fun onInstructionsAcknowledged() {
+        _uiState.update { it.copy(acknowledgedInstructions = true) }
+    }
+
+    /**
+     * Called when auto capture has timed out or if capability is not supported
+     */
+    private fun allowManualCapture() {
+        _uiState.update { it.copy(showManualCaptureButton = true) }
+    }
+
+    fun onPhotoSelectedFromGallery(selectedPhoto: File?) {
+        if (selectedPhoto == null) {
+            Timber.e("selectedPhoto is null")
+            _uiState.update {
+                it.copy(errorMessage = R.string.si_doc_v_capture_error_subtitle)
+            }
+        } else {
+            _uiState.update {
+                it.copy(acknowledgedInstructions = true, documentImageToConfirm = selectedPhoto)
+            }
+        }
+    }
+
+    /**
+     * To be called when auto capture determines the image quality is sufficient or when the user
+     * taps the manual capture button
+     */
+    fun captureDocument(cameraState: CameraState) {
+        // todo: lock this method to prevent multiple calls
+        val documentFile = createDocumentFile()
+        cameraState.takePicture(documentFile) { result ->
+            when (result) {
+                is ImageCaptureResult.Success -> {
+                    _uiState.update { it.copy(documentImageToConfirm = documentFile) }
+                }
+
+                is ImageCaptureResult.Error -> {
+                    Timber.e("Error capturing document", result.throwable)
+                    _uiState.update {
+                        it.copy(errorMessage = R.string.si_doc_v_capture_error_subtitle)
+                    }
+                }
+            }
+        }
+    }
+
+    fun onRetry() {
+        // It is safe to delete the file here, EVEN THOUGH it may have been selected from gallery
+        // because the URI we get back from the PhotoPicker does not grant us write access
+        uiState.value.documentImageToConfirm?.delete()
+        _uiState.update {
+            it.copy(
+                errorMessage = null,
+                documentImageToConfirm = null,
+                acknowledgedInstructions = false,
+            )
+        }
+    }
+}

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
@@ -1,9 +1,7 @@
 package com.smileidentity.viewmodel.document
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.smileidentity.R
 import com.smileidentity.util.createDocumentFile
 import com.ujizin.camposer.state.CameraState
 import com.ujizin.camposer.state.ImageCaptureResult
@@ -21,7 +19,7 @@ data class DocumentCaptureUiState(
     val areEdgesDetected: Boolean = false,
     val showManualCaptureButton: Boolean = false,
     val documentImageToConfirm: File? = null,
-    @StringRes val errorMessage: Int? = null,
+    val captureError: Throwable? = null,
 )
 
 class DocumentCaptureViewModel : ViewModel() {
@@ -49,10 +47,9 @@ class DocumentCaptureViewModel : ViewModel() {
 
     fun onPhotoSelectedFromGallery(selectedPhoto: File?) {
         if (selectedPhoto == null) {
-            Timber.e("selectedPhoto is null")
-            _uiState.update {
-                it.copy(errorMessage = R.string.si_doc_v_capture_error_subtitle)
-            }
+            val throwable = IllegalStateException("selectedPhoto is null")
+            Timber.w(throwable)
+            _uiState.update { it.copy(captureError = throwable) }
         } else {
             _uiState.update {
                 it.copy(acknowledgedInstructions = true, documentImageToConfirm = selectedPhoto)
@@ -75,9 +72,7 @@ class DocumentCaptureViewModel : ViewModel() {
 
                 is ImageCaptureResult.Error -> {
                     Timber.e("Error capturing document", result.throwable)
-                    _uiState.update {
-                        it.copy(errorMessage = R.string.si_doc_v_capture_error_subtitle)
-                    }
+                    _uiState.update { it.copy(captureError = result.throwable) }
                 }
             }
         }
@@ -89,7 +84,7 @@ class DocumentCaptureViewModel : ViewModel() {
         uiState.value.documentImageToConfirm?.delete()
         _uiState.update {
             it.copy(
-                errorMessage = null,
+                captureError = null,
                 documentImageToConfirm = null,
                 acknowledgedInstructions = false,
             )

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
@@ -41,7 +41,6 @@ internal class OrchestratedDocumentViewModel(
     private val userId: String,
     private val jobId: String,
     private val idType: Document,
-    private val idAspectRatio: Float? = idType.aspectRatio,
     private val captureBothSides: Boolean = false,
     private var selfieFile: File? = null,
 ) : ViewModel() {

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
@@ -1,6 +1,5 @@
 package com.smileidentity.viewmodel.document
 
-import android.graphics.Bitmap
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -9,6 +8,7 @@ import com.smileidentity.SmileID
 import com.smileidentity.compose.components.ProcessingState
 import com.smileidentity.models.AuthenticationRequest
 import com.smileidentity.models.Document
+import com.smileidentity.models.DocumentCaptureFlow
 import com.smileidentity.models.IdInfo
 import com.smileidentity.models.JobStatusRequest
 import com.smileidentity.models.JobType
@@ -20,11 +20,7 @@ import com.smileidentity.results.DocumentVerificationResult
 import com.smileidentity.results.SmartSelfieResult
 import com.smileidentity.results.SmileIDCallback
 import com.smileidentity.results.SmileIDResult
-import com.smileidentity.util.createDocumentFile
 import com.smileidentity.util.getExceptionHandler
-import com.smileidentity.util.postProcessImage
-import com.ujizin.camposer.state.CameraState
-import com.ujizin.camposer.state.ImageCaptureResult
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,15 +28,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.File
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 
-data class OrchestratedDocumentUiState(
-    val frontDocumentImageToConfirm: File? = null,
-    val backDocumentImageToConfirm: File? = null,
-    val showSelfieCapture: Boolean = false,
-    val processingState: ProcessingState? = null,
+internal data class OrchestratedDocumentUiState(
+    val currentStep: DocumentCaptureFlow = DocumentCaptureFlow.FrontDocumentCapture,
     @StringRes val errorMessage: Int? = null,
 )
 
@@ -48,11 +38,12 @@ data class OrchestratedDocumentUiState(
  * @param selfieFile The selfie image file to use for authentication. If null, selfie capture will
  * be performed
  */
-class OrchestratedDocumentViewModel(
+internal class OrchestratedDocumentViewModel(
     private val userId: String,
     private val jobId: String,
     private val idType: Document,
     private val idAspectRatio: Float? = idType.aspectRatio,
+    private val captureBothSides: Boolean = false,
     private var selfieFile: File? = null,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(OrchestratedDocumentUiState())
@@ -61,77 +52,41 @@ class OrchestratedDocumentViewModel(
     private var documentFrontFile: File? = null
     private var documentBackFile: File? = null
 
-    internal fun takeButtonCaptureDocument(
-        cameraState: CameraState,
-        hasBackSide: Boolean,
-    ) {
-        viewModelScope.launch {
-            try {
-                val documentFile =
-                    captureDocument(cameraState = cameraState, forBackSide = hasBackSide)
-                Timber.v("Capturing document image to $documentFile and is $hasBackSide")
-                _uiState.update {
-                    if (hasBackSide) {
-                        it.copy(backDocumentImageToConfirm = documentFile)
-                    } else {
-                        it.copy(
-                            frontDocumentImageToConfirm = documentFile,
-                        )
-                    }
-                }
-            } catch (e: Exception) {
-                Timber.e("Error capturing document", e)
-                _uiState.update { it.copy(errorMessage = R.string.si_doc_v_capture_error_subtitle) }
+    fun onDocumentFrontConfirmed(documentImageFile: File) {
+        documentFrontFile = documentImageFile
+        if (captureBothSides) {
+            _uiState.update {
+                it.copy(currentStep = DocumentCaptureFlow.BackDocumentCapture, errorMessage = null)
             }
+        } else if (selfieFile == null) {
+            _uiState.update {
+                it.copy(currentStep = DocumentCaptureFlow.SelfieCapture, errorMessage = null)
+            }
+        } else {
+            submitJob(documentFrontFile!!)
         }
     }
 
-    /**
-     * Captures a document image using the given [cameraState] and returns the processed image as a [Bitmap].
-     * If an error occurs during capture or processing, the coroutine will be resumed with an exception.
-     * The [documentFrontFile] or [documentBackFile] variable will be updated with the captured image file,
-     * and the UI state will be updated accordingly.`
-     */
-    private suspend fun captureDocument(cameraState: CameraState, forBackSide: Boolean) =
-        suspendCoroutine {
-            if (forBackSide) {
-                documentBackFile = createDocumentFile()
-            } else {
-                documentFrontFile = createDocumentFile()
+    fun onDocumentBackConfirmed(documentImageFile: File) {
+        documentBackFile = documentImageFile
+        if (selfieFile == null) {
+            _uiState.update {
+                it.copy(currentStep = DocumentCaptureFlow.SelfieCapture, errorMessage = null)
             }
-            val documentFile = if (forBackSide) documentBackFile!! else documentFrontFile!!
-            cameraState.takePicture(documentFile) { result ->
-                when (result) {
-                    is ImageCaptureResult.Error -> it.resumeWithException(result.throwable)
-                    is ImageCaptureResult.Success -> it.resume(
-                        postProcessImage(file = documentFile, desiredAspectRatio = idAspectRatio),
-                    )
-                }
-            }
-        }
-
-    fun saveFileFromGallerySelection(
-        documentFile: File?,
-        isBackSide: Boolean = false,
-    ) {
-        _uiState.update {
-            if (isBackSide) {
-                it.copy(backDocumentImageToConfirm = documentFile)
-            } else {
-                it.copy(
-                    frontDocumentImageToConfirm = documentFile,
-                )
-            }
+        } else {
+            submitJob(documentFrontFile!!)
         }
     }
 
     fun submitJob(documentFrontFile: File, documentBackFile: File? = null): Job {
-        _uiState.update { it.copy(processingState = ProcessingState.InProgress) }
+        _uiState.update {
+            it.copy(currentStep = DocumentCaptureFlow.ProcessingScreen(ProcessingState.InProgress))
+        }
         val proxy = { e: Throwable ->
             result = SmileIDResult.Error(e)
             _uiState.update {
                 it.copy(
-                    processingState = ProcessingState.Error,
+                    currentStep = DocumentCaptureFlow.ProcessingScreen(ProcessingState.Error),
                     errorMessage = R.string.si_processing_error_subtitle,
                 )
             }
@@ -182,62 +137,63 @@ class OrchestratedDocumentViewModel(
                     jobStatusResponse = jobStatusResponse,
                 ),
             )
-            _uiState.update { it.copy(processingState = ProcessingState.Success) }
-        }
-    }
-
-    fun onDocumentConfirmed() {
-        if (selfieFile != null) {
-            submitJob(documentFrontFile = documentFrontFile!!, documentBackFile = documentBackFile)
-        } else {
-            _uiState.update { it.copy(showSelfieCapture = true) }
+            _uiState.update {
+                it.copy(
+                    currentStep = DocumentCaptureFlow.ProcessingScreen(
+                        ProcessingState.Success,
+                    ),
+                )
+            }
         }
     }
 
     fun onDocumentRejected(isBackSide: Boolean) {
-        _uiState.update {
-            if (isBackSide) {
-                it.copy(backDocumentImageToConfirm = null)
-            } else {
-                it.copy(frontDocumentImageToConfirm = null)
-            }
-        }
-        if (isBackSide) {
-            documentBackFile?.delete()?.also { deleted ->
-                if (!deleted) Timber.w("Failed to delete $documentBackFile")
-            }
-            documentBackFile = null
-        } else {
-            documentFrontFile?.delete()?.also { deleted ->
-                if (!deleted) Timber.w("Failed to delete $documentFrontFile")
-            }
-            documentFrontFile = null
-        }
-        result = null
+        // TODO: Handle step cancellation (i.e. deliver result back to caller)
+        // _uiState.update {
+        //     if (isBackSide) {
+        //         it.copy(backDocumentImageToConfirm = null)
+        //     } else {
+        //         it.copy(frontDocumentImageToConfirm = null)
+        //     }
+        // }
+        // if (isBackSide) {
+        //     documentBackFile?.delete()?.also { deleted ->
+        //         if (!deleted) Timber.w("Failed to delete $documentBackFile")
+        //     }
+        //     documentBackFile = null
+        // } else {
+        //     documentFrontFile?.delete()?.also { deleted ->
+        //         if (!deleted) Timber.w("Failed to delete $documentFrontFile")
+        //     }
+        //     documentFrontFile = null
+        // }
+        // result = null
     }
 
     fun onRetry(hasBackSide: Boolean) {
-        // If document files are present, all captures were completed, so we're retrying a network
-        // issue
-        when {
-            hasBackSide -> if (documentFrontFile != null && documentBackFile != null) {
-                submitJob(documentFrontFile!!, documentBackFile)
-            } else {
-                _uiState.update {
-                    it.copy(processingState = null)
-                }
-            }
+        // TODO: Retry network submission (or just restart the flow?)
 
-            else -> {
-                if (documentFrontFile != null) {
-                    submitJob(documentFrontFile!!)
-                } else {
-                    _uiState.update {
-                        it.copy(processingState = null)
-                    }
-                }
-            }
-        }
+        // // If document files are present, all captures were completed, so we're retrying a network
+        // // issue
+        // when {
+        //     hasBackSide -> if (documentFrontFile != null && documentBackFile != null) {
+        //         submitJob(documentFrontFile!!, documentBackFile)
+        //     } else {
+        //         _uiState.update {
+        //             it.copy(processingState = null)
+        //         }
+        //     }
+        //
+        //     else -> {
+        //         if (documentFrontFile != null) {
+        //             submitJob(documentFrontFile!!)
+        //         } else {
+        //             _uiState.update {
+        //                 it.copy(processingState = null)
+        //             }
+        //         }
+        //     }
+        // }
     }
 
     fun onFinished(callback: SmileIDCallback<DocumentVerificationResult>) {
@@ -246,7 +202,9 @@ class OrchestratedDocumentViewModel(
 
     fun onSelfieCaptureError(error: SmileIDResult.Error) {
         Timber.w("Selfie capture error: $error")
-        _uiState.update { it.copy(processingState = ProcessingState.Error) }
+        _uiState.update {
+            it.copy(currentStep = DocumentCaptureFlow.ProcessingScreen(ProcessingState.Error))
+        }
     }
 
     fun onSelfieCaptureSuccess(it: SmileIDResult.Success<SmartSelfieResult>) {

--- a/sample/src/main/java/com/smileidentity/sample/activity/JavaActivity.java
+++ b/sample/src/main/java/com/smileidentity/sample/activity/JavaActivity.java
@@ -117,7 +117,7 @@ public class JavaActivity extends FragmentActivity {
     }
 
     private void doDocumentVerification() {
-        Document document = new Document("GH", "DRIVERS_LICENSE", 1.6f);
+        Document document = new Document("GH", "DRIVERS_LICENSE");
         DocumentVerificationFragment documentVerificationFragment = DocumentVerificationFragment
             .newInstance(document);
         getSupportFragmentManager().setFragmentResultListener(

--- a/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
@@ -259,6 +259,7 @@ fun MainScreen(
                         idType = documentType,
                         showInstructions = true,
                         allowGalleryUpload = true,
+                        captureBothSides = true,
                     ) { result ->
                         viewModel.onDocumentVerificationResult(userId, jobId, result)
                         navController.popBackStack(


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/10433/document-verification-image-analysis

## Summary

This attempts to break the current document verification flow into slightly more modular chunks. This allows us to re-use the same document capture components for both front and back capture (which will eventually encompass image analysis) without needing to handle each side individually

This simplification is done by modifying the overall routing logic. Previously, we had organized everything into many top level screens. Now, it is organized into 3 main steps: Document Front capture, Document Back capture, and Selfie Capture. 

The Document (Front/Back) Capture both call a re-usable DocumentCapture composable (with its own dedicated viewmodel) now. 

The DocumentCapture flow encompasses: displaying instructions, selecting from gallery, taking a picture, and image confirmation

## Screenshot

The UI and overall behavior should be unchanged
