### PR TITLE
Luminance detection

### DIFF
--- a/lib/src/androidTest/java/com/smileidentity/compose/document/DocumentCaptureScreenTest.kt
+++ b/lib/src/androidTest/java/com/smileidentity/compose/document/DocumentCaptureScreenTest.kt
@@ -1,11 +1,11 @@
 package com.smileidentity.compose.document
 
 import android.Manifest
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.rule.GrantPermissionRule
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
@@ -13,8 +13,6 @@ import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
 import com.google.common.truth.Truth.assertThat
-import com.smileidentity.R
-import com.smileidentity.models.Document
 import org.junit.Rule
 import org.junit.Test
 
@@ -28,47 +26,34 @@ class DocumentCaptureScreenTest {
     @OptIn(ExperimentalPermissionsApi::class)
     private lateinit var permissionState: PermissionState
 
-    private val testDocument = Document("KE", "ID_CARD")
-
     @OptIn(ExperimentalPermissionsApi::class)
     @Test
     fun shouldShowPreviewWhenPermissionsGranted() {
         // given
         val cameraPreviewTag = "document_camera_preview"
+        val instructionsTag = "document_capture_instructions_screen"
 
         // when
         composeTestRule.setContent {
             permissionState = rememberPermissionState(Manifest.permission.CAMERA)
             DocumentCaptureScreen(
-                titleText = stringResource(id = R.string.si_doc_v_capture_instructions_front_title),
-                subtitleText = stringResource(id = R.string.si_doc_v_capture_instructions_subtitle),
-                idType = testDocument,
+                side = DocumentCaptureSide.Front,
+                showInstructions = true,
+                showAttribution = true,
+                allowGallerySelection = true,
+                instructionsTitleText = "",
+                instructionsSubtitleText = "",
+                captureTitleText = "",
+                idAspectRatio = null,
+                onConfirm = {},
+                onError = {},
             )
         }
 
         // then
         assertThat(permissionState.status.isGranted).isTrue()
         assertThat(permissionState.status.shouldShowRationale).isFalse()
-        composeTestRule.onNodeWithTag(cameraPreviewTag).assertIsDisplayed()
-    }
-
-    @Test
-    fun shouldShowCameraPreview() {
-        // given
-        val titleText = "Front of ID"
-        val subtitleText = "Make sure all the corners are visible and there is no glare"
-        val cameraPreviewTag = "document_camera_preview"
-
-        // when
-        composeTestRule.setContent {
-            DocumentCaptureScreen(
-                titleText = titleText,
-                subtitleText = subtitleText,
-                idType = testDocument,
-            )
-        }
-
-        // then
+        composeTestRule.onNodeWithTag(instructionsTag).performClick()
         composeTestRule.onNodeWithTag(cameraPreviewTag).assertIsDisplayed()
     }
 
@@ -77,18 +62,27 @@ class DocumentCaptureScreenTest {
         // given
         val titleText = "Front of ID"
         val subtitleText = "Make sure all the corners are visible and there is no glare"
+        val captureTitle = "captureTitle"
 
         // when
         composeTestRule.setContent {
             DocumentCaptureScreen(
-                titleText = titleText,
-                subtitleText = subtitleText,
-                idType = testDocument,
+                side = DocumentCaptureSide.Front,
+                showInstructions = true,
+                showAttribution = true,
+                allowGallerySelection = true,
+                instructionsTitleText = titleText,
+                instructionsSubtitleText = subtitleText,
+                captureTitleText = "",
+                idAspectRatio = null,
+                onConfirm = {},
+                onError = {},
             )
         }
 
         // then
         composeTestRule.onNodeWithText(titleText, substring = true).assertIsDisplayed()
         composeTestRule.onNodeWithText(subtitleText, substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText(captureTitle, substring = true).assertIsDisplayed()
     }
 }

--- a/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
@@ -63,9 +63,6 @@ internal fun OrchestratedDocumentVerificationScreen(
             captureTitleText = stringResource(
                 id = R.string.si_doc_v_capture_instructions_front_title,
             ),
-            captureSubtitleText = stringResource(
-                id = R.string.si_doc_v_capture_instructions_subtitle,
-            ),
             idAspectRatio = idAspectRatio,
             onConfirm = viewModel::onDocumentFrontCaptureSuccess,
             onError = viewModel::onError,
@@ -82,9 +79,6 @@ internal fun OrchestratedDocumentVerificationScreen(
             ),
             captureTitleText = stringResource(
                 id = R.string.si_doc_v_capture_instructions_back_title,
-            ),
-            captureSubtitleText = stringResource(
-                id = R.string.si_doc_v_capture_instructions_subtitle,
             ),
             idAspectRatio = idAspectRatio,
             onConfirm = viewModel::onDocumentBackCaptureSuccess,

--- a/lib/src/main/java/com/smileidentity/compose/selfie/SelfieCaptureScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/selfie/SelfieCaptureScreen.kt
@@ -111,7 +111,7 @@ internal fun SelfieCaptureScreen(
                 .fillMaxSize(),
         ) {
             Text(
-                text = stringResource(uiState.currentDirective.displayText),
+                text = stringResource(uiState.directive.displayText),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.secondary,
                 textAlign = TextAlign.Center,

--- a/lib/src/main/java/com/smileidentity/viewmodel/SelfieViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/SelfieViewModel.kt
@@ -57,14 +57,14 @@ const val MAX_FACE_AREA_THRESHOLD = 0.25f
 private const val SMILE_THRESHOLD = 0.8f
 
 data class SelfieUiState(
-    val currentDirective: Directive = Directive.InitialInstruction,
+    val directive: SelfieDirective = SelfieDirective.InitialInstruction,
     val progress: Float = 0f,
     val selfieToConfirm: File? = null,
     val processingState: ProcessingState? = null,
     @StringRes val errorMessage: Int? = null,
 )
 
-enum class Directive(@StringRes val displayText: Int) {
+enum class SelfieDirective(@StringRes val displayText: Int) {
     InitialInstruction(R.string.si_smart_selfie_instructions),
     Capturing(R.string.si_smart_selfie_directive_capturing),
     EnsureFaceInFrame(R.string.si_smart_selfie_directive_unable_to_detect_face),
@@ -82,7 +82,7 @@ class SelfieViewModel(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(SelfieUiState())
 
-    // Debounce to avoid spamming Directive updates so that they can be read by the user
+    // Debounce to avoid spamming SelfieDirective updates so that they can be read by the user
     @OptIn(FlowPreview::class)
     val uiState = _uiState.asStateFlow().debounce(UI_DEBOUNCE_DURATION).stateIn(
         viewModelScope,
@@ -120,7 +120,7 @@ class SelfieViewModel(
         val inputImage = InputImage.fromMediaImage(image, imageProxy.imageInfo.rotationDegrees)
         faceDetector.process(inputImage).addOnSuccessListener { faces ->
             if (faces.isEmpty()) {
-                _uiState.update { it.copy(currentDirective = Directive.EnsureFaceInFrame) }
+                _uiState.update { it.copy(directive = SelfieDirective.EnsureFaceInFrame) }
                 // If no faces are detected for a while, reset the state
                 if (elapsedTimeMs > NO_FACE_RESET_DELAY_MS) {
                     _uiState.update {
@@ -140,7 +140,7 @@ class SelfieViewModel(
 
             // Ensure only 1 face is in frame
             if (faces.size > 1) {
-                _uiState.update { it.copy(currentDirective = Directive.EnsureOnlyOneFace) }
+                _uiState.update { it.copy(directive = SelfieDirective.EnsureOnlyOneFace) }
                 return@addOnSuccessListener
             }
 
@@ -152,31 +152,31 @@ class SelfieViewModel(
                 face.boundingBox.top >= 0 &&
                 face.boundingBox.bottom <= inputImage.height
             if (!faceCornersInImage) {
-                _uiState.update { it.copy(currentDirective = Directive.EnsureFaceInFrame) }
+                _uiState.update { it.copy(directive = SelfieDirective.EnsureFaceInFrame) }
                 return@addOnSuccessListener
             }
 
             // Check that the face is close enough to the camera
             val faceFillRatio = (face.boundingBox.area / inputImage.area.toFloat())
             if (faceFillRatio < MIN_FACE_AREA_THRESHOLD) {
-                _uiState.update { it.copy(currentDirective = Directive.MoveCloser) }
+                _uiState.update { it.copy(directive = SelfieDirective.MoveCloser) }
                 return@addOnSuccessListener
             }
 
             // Check that the face is not too close to the camera
             if (faceFillRatio > MAX_FACE_AREA_THRESHOLD) {
-                _uiState.update { it.copy(currentDirective = Directive.MoveAway) }
+                _uiState.update { it.copy(directive = SelfieDirective.MoveAway) }
                 return@addOnSuccessListener
             }
 
             // Ask the user to start smiling partway through liveness images
             val isSmiling = (face.smilingProbability ?: 0f) > SMILE_THRESHOLD
             if (livenessFiles.size > NUM_LIVENESS_IMAGES / 2 && !isSmiling) {
-                _uiState.update { it.copy(currentDirective = Directive.Smile) }
+                _uiState.update { it.copy(directive = SelfieDirective.Smile) }
                 return@addOnSuccessListener
             }
 
-            _uiState.update { it.copy(currentDirective = Directive.Capturing) }
+            _uiState.update { it.copy(directive = SelfieDirective.Capturing) }
 
             // Perform the rotation checks *after* changing directive to Capturing -- we don't want
             // to explicitly tell the user to move their head

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
@@ -1,8 +1,15 @@
 package com.smileidentity.viewmodel.document
 
+import android.graphics.ImageFormat.YUV_420_888
+import androidx.annotation.StringRes
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.smileidentity.R
 import com.smileidentity.util.createDocumentFile
+import com.smileidentity.util.postProcessImage
+import com.smileidentity.util.toByteArray
 import com.ujizin.camposer.state.CameraState
 import com.ujizin.camposer.state.ImageCaptureResult
 import kotlinx.coroutines.delay
@@ -14,8 +21,12 @@ import timber.log.Timber
 import java.io.File
 import kotlin.time.Duration.Companion.seconds
 
+private const val INTRA_IMAGE_MIN_DELAY_MS = 350
+private const val LUMINOSITY_THRESHOLD = 35
+
 data class DocumentCaptureUiState(
     val acknowledgedInstructions: Boolean = false,
+    val directive: DocumentDirective = DocumentDirective.DefaultInstructions,
     val areEdgesDetected: Boolean = false,
     val showManualCaptureButton: Boolean = false,
     val documentImageToConfirm: File? = null,
@@ -23,27 +34,27 @@ data class DocumentCaptureUiState(
     val showCaptureInProgress: Boolean = false,
 )
 
-class DocumentCaptureViewModel : ViewModel() {
+enum class DocumentDirective(@StringRes val displayText: Int) {
+    DefaultInstructions(R.string.si_doc_v_capture_directive_default),
+    EnsureWellLit(R.string.si_doc_v_capture_directive_ensure_well_lit),
+    Capturing(R.string.si_doc_v_capture_directive_capturing),
+}
+
+class DocumentCaptureViewModel : ViewModel(), ImageAnalysis.Analyzer {
     private val _uiState = MutableStateFlow(DocumentCaptureUiState())
     val uiState = _uiState.asStateFlow()
+    private var lastAutoCaptureTimeMs = 0L
 
     init {
         // Show manual capture after 10 seconds, using coroutine
         viewModelScope.launch {
             delay(10.seconds)
-            allowManualCapture()
+            _uiState.update { it.copy(showManualCaptureButton = true) }
         }
     }
 
     fun onInstructionsAcknowledged() {
         _uiState.update { it.copy(acknowledgedInstructions = true) }
-    }
-
-    /**
-     * Called when auto capture has timed out or if capability is not supported
-     */
-    private fun allowManualCapture() {
-        _uiState.update { it.copy(showManualCaptureButton = true) }
     }
 
     fun onPhotoSelectedFromGallery(selectedPhoto: File?) {
@@ -67,14 +78,16 @@ class DocumentCaptureViewModel : ViewModel() {
             Timber.v("Already capturing. Skipping duplicate capture request")
             return
         }
-        _uiState.update { it.copy(showCaptureInProgress = true) }
+        _uiState.update {
+            it.copy(showCaptureInProgress = true, directive = DocumentDirective.Capturing)
+        }
         val documentFile = createDocumentFile()
         cameraState.takePicture(documentFile) { result ->
             when (result) {
                 is ImageCaptureResult.Success -> {
                     _uiState.update {
                         it.copy(
-                            documentImageToConfirm = documentFile,
+                            documentImageToConfirm = postProcessImage(documentFile),
                             showCaptureInProgress = false,
                         )
                     }
@@ -99,7 +112,30 @@ class DocumentCaptureViewModel : ViewModel() {
                 captureError = null,
                 documentImageToConfirm = null,
                 acknowledgedInstructions = false,
+                directive = DocumentDirective.DefaultInstructions,
             )
+        }
+    }
+
+    override fun analyze(imageProxy: ImageProxy) = imageProxy.use {
+        // YUV_420_888 is the format produced by CameraX
+        check(imageProxy.format == YUV_420_888) { "Unsupported format: ${imageProxy.format}" }
+
+        val elapsedTimeMs = System.currentTimeMillis() - lastAutoCaptureTimeMs
+        if (uiState.value.showCaptureInProgress || elapsedTimeMs < INTRA_IMAGE_MIN_DELAY_MS) {
+            return
+        }
+        lastAutoCaptureTimeMs = System.currentTimeMillis()
+
+        // planes[0] is the Y plane aka "luma"
+        val data = imageProxy.planes[0].buffer.toByteArray()
+        val pixels = data.map { it.toInt() and 0xFF }
+        val luminance = pixels.average()
+
+        if (luminance < LUMINOSITY_THRESHOLD) {
+            _uiState.update { it.copy(directive = DocumentDirective.EnsureWellLit) }
+        } else {
+            _uiState.update { it.copy(directive = DocumentDirective.DefaultInstructions) }
         }
     }
 }

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -57,7 +57,9 @@
     <string name="si_doc_v_instruction_back_subtitle">For this ID type, we require that you submit the back of the ID</string>
     <string name="si_doc_v_capture_instructions_front_title">Front of ID</string>
     <string name="si_doc_v_capture_instructions_back_title">Back of ID</string>
-    <string name="si_doc_v_capture_instructions_subtitle">Make sure all the corners are visible and there is no glare</string>
+    <string name="si_doc_v_capture_directive_default">Please center your ID within the frame. Ensure all corners are visible and there is no glare</string>
+    <string name="si_doc_v_capture_directive_ensure_well_lit">Ensure the document is well lit</string>
+    <string name="si_doc_v_capture_directive_capturing">Capturing…</string>
     <string name="si_doc_v_capture_error_subtitle">Your document capture failed to process</string>
     <string name="si_doc_v_validation_image_too_small">Selected image is too small. Please select a larger resolution image.</string>
     <string name="si_doc_v_confirmation_dialog_title">Is the document clear and readable?</string>

--- a/lib/src/test/java/com/smileidentity/viewmodel/SelfieViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/SelfieViewModelTest.kt
@@ -34,7 +34,7 @@ class SelfieViewModelTest {
     @Test
     fun `uiState should be initialized with the correct defaults`() {
         val uiState = subject.uiState.value
-        assertEquals(Directive.InitialInstruction, uiState.currentDirective)
+        assertEquals(SelfieDirective.InitialInstruction, uiState.directive)
         assertEquals(0f, uiState.progress)
         assertEquals(null, uiState.selfieToConfirm)
         assertEquals(null, uiState.processingState)


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/10433/document-verification-image-analysis

## Summary

Adds luminance detection. It is accomplished by averaging pixels in the luma plane of the YUV format. In support of this work, this PR also:

- Shows the manual capture button only after 10 seconds
- Adds a `DocumentDirective`
- Renames the selfie capture's `Directive` to `SelfieDirective`
- Updates the rotation/orientation handling code

## Known Issues
- Luminance threshold may need some fine tuning
- Need to double check with product whether we want to show these granular instructions to users for document capture
- While the manual capture button shows up only after 10 seconds, no auto capture is performed yet