### PR TITLE
Add focus detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 10.0.0-beta07 (unreleased)
 
 ### Added
+- Detection of bad lighting in Document Verification
+- Detection of unfocused states in Document Verification
+- 
 
 ### Fixed
 - Fix a Document Verification bug where selfie wasn't captured when also capturing the back of an ID
@@ -10,6 +13,7 @@
 ### Changed
 - `resultCode`s, `code`s, and `BankCode.code`s are all now `String`s in order to maintain leading 0s
 - Bump Compose BOM to 2023.08.00
+- Bump Camposer to 0.3.0 (transitively bumping CameraX as well)
 
 ### Removed
 

--- a/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureInstructionsScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureInstructionsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -110,7 +111,7 @@ fun DocumentCaptureInstructionsScreen(
             }
         },
         columnWidth = 320.dp,
-        modifier = modifier,
+        modifier = modifier.testTag("document_capture_instructions_screen"),
     )
 }
 

--- a/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -155,6 +156,7 @@ internal fun DocumentCaptureScreen(
             showManualCaptureButton = uiState.showManualCaptureButton,
             onCaptureClicked = viewModel::captureDocument,
             imageAnalyzer = viewModel,
+            onFocusEvent = viewModel::onFocusEvent,
             modifier = modifier,
         )
     }
@@ -170,10 +172,14 @@ private fun CaptureScreenContent(
     showManualCaptureButton: Boolean,
     onCaptureClicked: (CameraState) -> Unit,
     imageAnalyzer: ImageAnalysis.Analyzer,
+    onFocusEvent: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val cameraState = rememberCameraState()
     val camSelector by rememberCamSelector(CamSelector.Back)
+    val lifecycleOwner = LocalLifecycleOwner.current
+    cameraState.controller.tapToFocusState.observe(lifecycleOwner, onFocusEvent)
+
     Column(modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
@@ -272,6 +278,7 @@ private fun CaptureScreenContentPreview() {
             showManualCaptureButton = true,
             onCaptureClicked = {},
             imageAnalyzer = {},
+            onFocusEvent = {},
         )
     }
 }

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
@@ -4,9 +4,9 @@ import android.graphics.ImageFormat.YUV_420_888
 import androidx.annotation.StringRes
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
-import androidx.camera.view.CameraController
 import androidx.camera.view.CameraController.TAP_TO_FOCUS_NOT_FOCUSED
 import androidx.camera.view.CameraController.TAP_TO_FOCUS_STARTED
+import androidx.camera.view.CameraController.TapToFocusStates
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.smileidentity.R
@@ -125,7 +125,7 @@ class DocumentCaptureViewModel : ViewModel(), ImageAnalysis.Analyzer {
         }
     }
 
-    fun onFocusEvent(@CameraController.TapToFocusStates focusEvent: Int) {
+    fun onFocusEvent(@TapToFocusStates focusEvent: Int) {
         isFocusing = focusEvent == TAP_TO_FOCUS_STARTED || focusEvent == TAP_TO_FOCUS_NOT_FOCUSED
         if (isFocusing) {
             _uiState.update { it.copy(directive = DocumentDirective.Focusing) }

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
@@ -4,6 +4,9 @@ import android.graphics.ImageFormat.YUV_420_888
 import androidx.annotation.StringRes
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
+import androidx.camera.view.CameraController
+import androidx.camera.view.CameraController.TAP_TO_FOCUS_NOT_FOCUSED
+import androidx.camera.view.CameraController.TAP_TO_FOCUS_STARTED
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.smileidentity.R
@@ -21,7 +24,7 @@ import timber.log.Timber
 import java.io.File
 import kotlin.time.Duration.Companion.seconds
 
-private const val INTRA_IMAGE_MIN_DELAY_MS = 350
+private const val ANALYSIS_SAMPLE_INTERVAL_MS = 350
 private const val LUMINOSITY_THRESHOLD = 35
 
 data class DocumentCaptureUiState(
@@ -37,13 +40,16 @@ data class DocumentCaptureUiState(
 enum class DocumentDirective(@StringRes val displayText: Int) {
     DefaultInstructions(R.string.si_doc_v_capture_directive_default),
     EnsureWellLit(R.string.si_doc_v_capture_directive_ensure_well_lit),
+    Focusing(R.string.si_doc_v_capture_directive_focusing),
     Capturing(R.string.si_doc_v_capture_directive_capturing),
 }
 
 class DocumentCaptureViewModel : ViewModel(), ImageAnalysis.Analyzer {
     private val _uiState = MutableStateFlow(DocumentCaptureUiState())
     val uiState = _uiState.asStateFlow()
-    private var lastAutoCaptureTimeMs = 0L
+    private var lastAnalysisTimeMs = 0L
+    private var isCapturing = false
+    private var isFocusing = false
 
     init {
         // Show manual capture after 10 seconds, using coroutine
@@ -74,15 +80,17 @@ class DocumentCaptureViewModel : ViewModel(), ImageAnalysis.Analyzer {
      * taps the manual capture button.
      */
     fun captureDocument(cameraState: CameraState) {
-        if (uiState.value.showCaptureInProgress) {
+        if (isCapturing) {
             Timber.v("Already capturing. Skipping duplicate capture request")
             return
         }
+        isCapturing = true
         _uiState.update {
             it.copy(showCaptureInProgress = true, directive = DocumentDirective.Capturing)
         }
         val documentFile = createDocumentFile()
         cameraState.takePicture(documentFile) { result ->
+            isCapturing = false
             when (result) {
                 is ImageCaptureResult.Success -> {
                     _uiState.update {
@@ -117,25 +125,38 @@ class DocumentCaptureViewModel : ViewModel(), ImageAnalysis.Analyzer {
         }
     }
 
+    fun onFocusEvent(@CameraController.TapToFocusStates focusEvent: Int) {
+        isFocusing = focusEvent == TAP_TO_FOCUS_STARTED || focusEvent == TAP_TO_FOCUS_NOT_FOCUSED
+        if (isFocusing) {
+            _uiState.update { it.copy(directive = DocumentDirective.Focusing) }
+        }
+    }
+
     override fun analyze(imageProxy: ImageProxy) = imageProxy.use {
         // YUV_420_888 is the format produced by CameraX
         check(imageProxy.format == YUV_420_888) { "Unsupported format: ${imageProxy.format}" }
 
-        val elapsedTimeMs = System.currentTimeMillis() - lastAutoCaptureTimeMs
-        if (uiState.value.showCaptureInProgress || elapsedTimeMs < INTRA_IMAGE_MIN_DELAY_MS) {
+        val elapsedTimeMs = System.currentTimeMillis() - lastAnalysisTimeMs
+        // When capturing or focusing, skip performing image analysis
+        if (isCapturing) {
+            _uiState.update { it.copy(directive = DocumentDirective.Capturing) }
+        } else if (isFocusing) {
+            _uiState.update { it.copy(directive = DocumentDirective.Focusing) }
+        } else if (elapsedTimeMs < ANALYSIS_SAMPLE_INTERVAL_MS) {
             return
-        }
-        lastAutoCaptureTimeMs = System.currentTimeMillis()
-
-        // planes[0] is the Y plane aka "luma"
-        val data = imageProxy.planes[0].buffer.toByteArray()
-        val pixels = data.map { it.toInt() and 0xFF }
-        val luminance = pixels.average()
-
-        if (luminance < LUMINOSITY_THRESHOLD) {
-            _uiState.update { it.copy(directive = DocumentDirective.EnsureWellLit) }
         } else {
-            _uiState.update { it.copy(directive = DocumentDirective.DefaultInstructions) }
+            lastAnalysisTimeMs = System.currentTimeMillis()
+
+            // planes[0] is the Y plane aka "luma"
+            val data = imageProxy.planes[0].buffer.toByteArray()
+            val pixels = data.map { it.toInt() and 0xFF }
+            val luminance = pixels.average()
+
+            if (luminance < LUMINOSITY_THRESHOLD) {
+                _uiState.update { it.copy(directive = DocumentDirective.EnsureWellLit) }
+            } else {
+                _uiState.update { it.copy(directive = DocumentDirective.DefaultInstructions) }
+            }
         }
     }
 }

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="si_doc_v_capture_instructions_back_title">Back of ID</string>
     <string name="si_doc_v_capture_directive_default">Please center your ID within the frame. Ensure all corners are visible and there is no glare</string>
     <string name="si_doc_v_capture_directive_ensure_well_lit">Ensure the document is well lit</string>
+    <string name="si_doc_v_capture_directive_focusing">Focusing…</string>
     <string name="si_doc_v_capture_directive_capturing">Capturing…</string>
     <string name="si_doc_v_capture_error_subtitle">Your document capture failed to process</string>
     <string name="si_doc_v_validation_image_too_small">Selected image is too small. Please select a larger resolution image.</string>

--- a/lib/src/test/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModelTest.kt
@@ -1,0 +1,116 @@
+package com.smileidentity.viewmodel.document
+
+import androidx.camera.view.CameraController
+import com.smileidentity.SmileID
+import com.ujizin.camposer.state.CameraState
+import com.ujizin.camposer.state.ImageCaptureResult
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.setMain
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DocumentCaptureViewModelTest {
+    private lateinit var subject: DocumentCaptureViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        SmileID.fileSavePath = "."
+        subject = DocumentCaptureViewModel()
+    }
+
+    @Test
+    fun `should acknowledge instructions`() {
+        // when
+        subject.onInstructionsAcknowledged()
+
+        // then
+        assertTrue(subject.uiState.value.acknowledgedInstructions)
+    }
+
+    @Test
+    fun `should save file from gallery`() {
+        // given
+        val documentFile = File.createTempFile("documentFront", ".jpg")
+
+        // when
+        subject.onPhotoSelectedFromGallery(documentFile)
+
+        // then
+        assertEquals(documentFile, subject.uiState.value.documentImageToConfirm)
+        assertTrue(subject.uiState.value.acknowledgedInstructions)
+    }
+
+    @Test
+    fun `should set state when starting capture`() {
+        // given
+        val cameraState: CameraState = mockk()
+        every { cameraState.takePicture(any(File::class), any()) } just Runs
+
+        // when
+        subject.captureDocument(cameraState)
+
+        // then
+        assertTrue(subject.uiState.value.showCaptureInProgress)
+        assertEquals(DocumentDirective.Capturing, subject.uiState.value.directive)
+    }
+
+    @Test
+    fun `should set state when capture failed`() {
+        // given
+        val cameraState: CameraState = mockk()
+        val slot = slot<(ImageCaptureResult) -> Unit>()
+        every { cameraState.takePicture(any(File::class), capture(slot)) } just Runs
+        subject.captureDocument(cameraState)
+        val expectedError = Exception("")
+        val captureResult = ImageCaptureResult.Error(expectedError)
+
+        // when
+        slot.captured.invoke(captureResult)
+
+        // then
+        assertFalse(subject.uiState.value.showCaptureInProgress)
+        assertEquals(expectedError, subject.uiState.value.captureError)
+    }
+
+    @Test
+    fun `should retry`() {
+        // given
+        val documentFile = File.createTempFile("documentFront", ".jpg")
+        subject.onPhotoSelectedFromGallery(documentFile)
+
+        // when
+        subject.onRetry()
+
+        // then
+        assertFalse(documentFile.exists())
+        assertNull(subject.uiState.value.documentImageToConfirm)
+        assertNull(subject.uiState.value.captureError)
+        assertFalse(subject.uiState.value.acknowledgedInstructions)
+        assertEquals(DocumentDirective.DefaultInstructions, subject.uiState.value.directive)
+    }
+
+    @Test
+    fun `should update focusing state`() {
+        // given
+        val focusEvent = CameraController.TAP_TO_FOCUS_STARTED
+
+        // when
+        subject.onFocusEvent(focusEvent)
+
+        // then
+        assertEquals(DocumentDirective.Focusing, subject.uiState.value.directive)
+    }
+}


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/10433/document-verification-image-analysis

## Summary

Adds focus detection and tests for `DocumentCaptureViewModel`

## Known Issues

- This does not yet gate the auto capture (it will come in a future PR)
- The focus state is exposed by CameraX as a `LiveData`. There do exist functions to convert this to a Compose compatible `State`, but I didn't choose this because it required an extra dependency and I wanted to send each updated value to viewmodel anyways