### PR TITLE
Document Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,21 @@
 ## 10.0.0-beta07 (unreleased)
 
 ### Added
-- Detection of bad lighting in Document Verification
-- Detection of unfocused states in Document Verification
+- Detection of bad lighting for Document Verification
+- Detection of unfocused states for Document Verification
+- Document detection for Document Verification
 
 ### Fixed
 - Fix a Document Verification bug where selfie wasn't captured when also capturing the back of an ID
+- Fixed a bug where the document bounding box border was slightly offset from document cutout
+- Fixed a bug where the wrong `ImageType` was being specified for back of ID images
 
 ### Changed
 - `resultCode`s, `code`s, and `BankCode.code`s are all now `String`s in order to maintain leading 0s
 - Bump Compose BOM to 2023.08.00
 - Include liveness images for Document Verification jobs, if selfie capture was not bypassed
 - Bump CameraX to 1.2.3
+- Slightly zoom in on the document capture preview and confirmation
 
 ### Removed
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ ksp = "1.9.0-1.0.13"
 ktlint-plugin = "11.5.1"
 leakcanary = "2.12"
 maven-publish = "0.25.3"
+mlkit-object-detection = "17.0.0"
 mockk = "1.13.7"
 moshi = "1.15.0"
 moshix = "0.24.0"
@@ -85,6 +86,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-immutable-collections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlin-immutable-collections" }
 leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 leakcanary-noop = { module = "com.squareup.leakcanary:leakcanary-android-release", version.ref = "leakcanary" }
+mlkit-object-detection = { module = "com.google.mlkit:object-detection", version.ref = "mlkit-object-detection" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }

--- a/lib/lib.gradle.kts
+++ b/lib/lib.gradle.kts
@@ -200,6 +200,9 @@ dependencies {
     // Unbundled model -- will be dynamically downloaded via Google Play Services
     implementation(libs.play.services.mlkit.face.detection)
 
+    // Bundled model
+    implementation(libs.mlkit.`object`.detection)
+
     testImplementation(libs.junit)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.coroutines.test)

--- a/lib/src/androidTest/java/com/smileidentity/compose/document/DocumentCaptureScreenTest.kt
+++ b/lib/src/androidTest/java/com/smileidentity/compose/document/DocumentCaptureScreenTest.kt
@@ -44,7 +44,7 @@ class DocumentCaptureScreenTest {
                 instructionsTitleText = "",
                 instructionsSubtitleText = "",
                 captureTitleText = "",
-                idAspectRatio = null,
+                knownIdAspectRatio = null,
                 onConfirm = {},
                 onError = {},
             )
@@ -74,7 +74,7 @@ class DocumentCaptureScreenTest {
                 instructionsTitleText = titleText,
                 instructionsSubtitleText = subtitleText,
                 captureTitleText = "",
-                idAspectRatio = null,
+                knownIdAspectRatio = null,
                 onConfirm = {},
                 onError = {},
             )

--- a/lib/src/main/java/com/smileidentity/compose/document/DocumentShapedBoundingBox.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/DocumentShapedBoundingBox.kt
@@ -49,8 +49,18 @@ fun DocumentShapedBoundingBox(
 
         // 2. Draw the outline of the bounding box and add a stroke that shows different edge
         // detection states
-        val outlineBoundingBoxWidth = size.width - DOCUMENT_BOUNDING_BOX_MARGINS
-        val outlineBoundingBoxHeight = outlineBoundingBoxWidth / aspectRatio
+
+        val (outlineBoundingBoxWidth, outlineBoundingBoxHeight) = if (aspectRatio >= 1) {
+            // Horizontal ID
+            val outlineBoundingBoxWidth = size.width - DOCUMENT_BOUNDING_BOX_MARGINS
+            val outlineBoundingBoxHeight = outlineBoundingBoxWidth / aspectRatio
+            outlineBoundingBoxWidth to outlineBoundingBoxHeight
+        } else {
+            // Vertical ID
+            val outlineBoundingBoxHeight = size.height - DOCUMENT_BOUNDING_BOX_MARGINS
+            val outlineBoundingBoxWidth = outlineBoundingBoxHeight * aspectRatio
+            outlineBoundingBoxWidth to outlineBoundingBoxHeight
+        }
         val outlineBoundingBoxX = (size.width - outlineBoundingBoxWidth) / 2
         val outlineBoundingBoxY = (size.height - outlineBoundingBoxHeight) / 2
         drawRoundRect(

--- a/lib/src/main/java/com/smileidentity/compose/document/DocumentShapedBoundingBox.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/DocumentShapedBoundingBox.kt
@@ -16,8 +16,7 @@ import androidx.compose.ui.unit.Dp
 import com.smileidentity.compose.preview.Preview
 import com.smileidentity.compose.preview.SmilePreviews
 
-const val DEFAULT_DOCUMENT_ASPECT_RATIO = 3.375f / 2.125f
-const val DOCUMENT_BOUNDING_BOX_MARGINS = 30f
+const val DOCUMENT_BOUNDING_BOX_MARGINS = 64f
 val DOCUMENT_BOUNDING_BOX_RADIUS = CornerRadius(30f, 30f)
 
 /**
@@ -33,7 +32,7 @@ val DOCUMENT_BOUNDING_BOX_RADIUS = CornerRadius(30f, 30f)
  */
 @Composable
 fun DocumentShapedBoundingBox(
-    aspectRatio: Float?,
+    aspectRatio: Float,
     areEdgesDetected: Boolean,
     modifier: Modifier = Modifier,
     strokeWidth: Dp = ProgressIndicatorDefaults.CircularStrokeWidth,
@@ -51,8 +50,7 @@ fun DocumentShapedBoundingBox(
         // 2. Draw the outline of the bounding box and add a stroke that shows different edge
         // detection states
         val outlineBoundingBoxWidth = size.width - DOCUMENT_BOUNDING_BOX_MARGINS
-        val outlineBoundingBoxHeight =
-            outlineBoundingBoxWidth / (aspectRatio ?: DEFAULT_DOCUMENT_ASPECT_RATIO)
+        val outlineBoundingBoxHeight = outlineBoundingBoxWidth / aspectRatio
         val outlineBoundingBoxX = (size.width - outlineBoundingBoxWidth) / 2
         val outlineBoundingBoxY = (size.height - outlineBoundingBoxHeight) / 2
         drawRoundRect(
@@ -71,14 +69,17 @@ fun DocumentShapedBoundingBox(
             color = Color.Transparent,
             blendMode = BlendMode.Clear,
             topLeft = Offset(
-                x = outlineBoundingBoxX,
+                x = outlineBoundingBoxX + (strokeWidth.toPx() / 2),
                 y = outlineBoundingBoxY + (strokeWidth.toPx() / 2),
             ),
             size = Size(
                 width = (outlineBoundingBoxWidth - strokeWidth.toPx()),
                 height = (outlineBoundingBoxHeight - strokeWidth.toPx()),
             ),
-            cornerRadius = DOCUMENT_BOUNDING_BOX_RADIUS,
+            cornerRadius = DOCUMENT_BOUNDING_BOX_RADIUS - CornerRadius(
+                strokeWidth.value,
+                strokeWidth.value,
+            ),
         )
     }
 }

--- a/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
@@ -63,7 +63,7 @@ internal fun OrchestratedDocumentVerificationScreen(
             captureTitleText = stringResource(
                 id = R.string.si_doc_v_capture_instructions_front_title,
             ),
-            idAspectRatio = idAspectRatio,
+            knownIdAspectRatio = idAspectRatio,
             onConfirm = viewModel::onDocumentFrontCaptureSuccess,
             onError = viewModel::onError,
         )
@@ -80,7 +80,7 @@ internal fun OrchestratedDocumentVerificationScreen(
             captureTitleText = stringResource(
                 id = R.string.si_doc_v_capture_instructions_back_title,
             ),
-            idAspectRatio = idAspectRatio,
+            knownIdAspectRatio = idAspectRatio,
             onConfirm = viewModel::onDocumentBackCaptureSuccess,
             onError = viewModel::onError,
         )

--- a/lib/src/main/java/com/smileidentity/networking/NetworkingUtil.kt
+++ b/lib/src/main/java/com/smileidentity/networking/NetworkingUtil.kt
@@ -54,7 +54,12 @@ fun File.asLivenessImage() = UploadImageInfo(
     image = this,
 )
 
-fun File.asDocumentImage() = UploadImageInfo(
+fun File.asDocumentFrontImage() = UploadImageInfo(
     imageTypeId = ImageType.IdCardJpgFile,
+    image = this,
+)
+
+fun File.asDocumentBackImage() = UploadImageInfo(
+    imageTypeId = ImageType.IdCardRearJpgFile,
     image = this,
 )

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.objects.ObjectDetection
+import com.google.mlkit.vision.objects.ObjectDetector
 import com.google.mlkit.vision.objects.defaults.ObjectDetectorOptions
 import com.smileidentity.R
 import com.smileidentity.util.createDocumentFile
@@ -52,6 +53,11 @@ enum class DocumentDirective(@StringRes val displayText: Int) {
 
 class DocumentCaptureViewModel(
     private val knownAspectRatio: Float?,
+    private val objectDetector: ObjectDetector = ObjectDetection.getClient(
+        ObjectDetectorOptions.Builder()
+            .setDetectorMode(ObjectDetectorOptions.SINGLE_IMAGE_MODE)
+            .build(),
+    ),
 ) : ViewModel(), ImageAnalysis.Analyzer {
     private val _uiState = MutableStateFlow(DocumentCaptureUiState())
     val uiState = _uiState.asStateFlow()
@@ -59,12 +65,6 @@ class DocumentCaptureViewModel(
     private var isCapturing = false
     private var isFocusing = false
     private val defaultAspectRatio get() = knownAspectRatio ?: 1f
-
-    private val objectDetector = ObjectDetection.getClient(
-        ObjectDetectorOptions.Builder()
-            .setDetectorMode(ObjectDetectorOptions.SINGLE_IMAGE_MODE)
-            .build(),
-    )
 
     init {
         _uiState.update { it.copy(idAspectRatio = defaultAspectRatio) }

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
@@ -14,7 +14,8 @@ import com.smileidentity.models.JobStatusRequest
 import com.smileidentity.models.JobType
 import com.smileidentity.models.PrepUploadRequest
 import com.smileidentity.models.UploadRequest
-import com.smileidentity.networking.asDocumentImage
+import com.smileidentity.networking.asDocumentBackImage
+import com.smileidentity.networking.asDocumentFrontImage
 import com.smileidentity.networking.asLivenessImage
 import com.smileidentity.networking.asSelfieImage
 import com.smileidentity.results.DocumentVerificationResult
@@ -119,8 +120,8 @@ internal class OrchestratedDocumentViewModel(
                 timestamp = authResponse.timestamp,
             )
             val prepUploadResponse = SmileID.api.prepUpload(prepUploadRequest)
-            val frontImageInfo = documentFrontFile.asDocumentImage()
-            val backImageInfo = documentBackFile?.asDocumentImage()
+            val frontImageInfo = documentFrontFile.asDocumentFrontImage()
+            val backImageInfo = documentBackFile?.asDocumentBackImage()
             val selfieImageInfo = selfieFile?.asSelfieImage() ?: throw IllegalStateException(
                 "Selfie file is null",
             )

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string name="si_doc_v_instruction_back_subtitle">For this ID type, we require that you submit the back of the ID</string>
     <string name="si_doc_v_capture_instructions_front_title">Front of ID</string>
     <string name="si_doc_v_capture_instructions_back_title">Back of ID</string>
-    <string name="si_doc_v_capture_directive_default">Please center your ID within the frame. Ensure all corners are visible and there is no glare</string>
+    <string name="si_doc_v_capture_directive_default">Please fill the frame with your ID. Ensure all corners are visible and there is no glare</string>
     <string name="si_doc_v_capture_directive_ensure_well_lit">Ensure the document is well lit</string>
     <string name="si_doc_v_capture_directive_focusing">Focusing…</string>
     <string name="si_doc_v_capture_directive_capturing">Capturing…</string>

--- a/lib/src/test/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModelTest.kt
@@ -28,7 +28,7 @@ class DocumentCaptureViewModelTest {
     fun setup() {
         Dispatchers.setMain(Dispatchers.Unconfined)
         SmileID.fileSavePath = "."
-        subject = DocumentCaptureViewModel()
+        subject = DocumentCaptureViewModel(knownAspectRatio = null)
     }
 
     @Test

--- a/lib/src/test/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/document/DocumentCaptureViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.smileidentity.viewmodel.document
 
 import androidx.camera.view.CameraController
+import com.google.mlkit.vision.objects.ObjectDetector
 import com.smileidentity.SmileID
 import com.ujizin.camposer.state.CameraState
 import com.ujizin.camposer.state.ImageCaptureResult
@@ -28,7 +29,8 @@ class DocumentCaptureViewModelTest {
     fun setup() {
         Dispatchers.setMain(Dispatchers.Unconfined)
         SmileID.fileSavePath = "."
-        subject = DocumentCaptureViewModel(knownAspectRatio = null)
+        val objectDetector: ObjectDetector = mockk()
+        subject = DocumentCaptureViewModel(knownAspectRatio = null, objectDetector)
     }
 
     @Test


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/10433/document-verification-image-analysis

## Summary

Adds document detection by using MLKit Object Detection. The bounding box changes shape depending on the detected aspect ratio. If an aspect ratio is passed in, the bounding box is held to that aspect ratio and the border will turn green only when the detected aspect ratio matches the passed in aspect ratio (within some threshold). 

Also fixes some small bugs: one where the document bounding box border was slightly offset from the document cutout and one where the wrong `ImageType` was being used for back of ID captures

A UX improvement was made to zoom in the document preview and confirmation, as a counter-measure against users capturing cropped documents

## Known Issues

- Auto capture is not performed yet. This will come in a future PR