### PR TITLE
Group Dependabot Updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,19 @@ updates:
       interval: "weekly"
       time: "10:00"
       timezone: "America/Los_Angeles"
+    groups:
+      # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      # Group updates together, so that they are all applied in a single PR.
+      kotlin:
+        # KSP and Kotlin updates need to be applied simultaneously
+        patterns:
+          - "com.google.devtools.ksp"
+          - "org.jetbrains.kotlin.*"
+      all:
+        # Group all patch and minor updates together. Kotlin/KSP updates belong to the first group
+        # so they will not be updated as part of this group
+        update-types:
+          - "patch"
+          - "minor"
+        patterns:
+          - "*"

--- a/lib/VERSION
+++ b/lib/VERSION
@@ -1,1 +1,1 @@
-10.0.0-beta06-SNAPSHOT
+10.0.0-beta07-SNAPSHOT


### PR DESCRIPTION
Support for grouped updates was recently added: https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/

This PR creates 2 groups for dependabot:
1. Kotlin and KSP, which always need to be bumped in lockstep
2. Minor and patches versions of remaining dependencies

Major version will be continue to be raised as individual PRs by dependabot