### PR TITLE
BVN Consent fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## 10.0.0-beta07 (unreleased)
+## 10.0.0-beta08 (unreleased)
+
+### Added
+- BVN Consent Screen
+- Dependency on `org.jetbrains.kotlinx:kotlinx-collections-immutable`
+
+### Fixed
+
+### Changed
+- Bump Sentry to 6.29.0
+
+### Removed
+
+## 10.0.0-beta07
 
 ### Added
 - Added BVN Verification for Nigeria

--- a/lib/VERSION
+++ b/lib/VERSION
@@ -1,1 +1,1 @@
-10.0.0-beta07-SNAPSHOT
+10.0.0-beta08-SNAPSHOT

--- a/lib/lib.gradle.kts
+++ b/lib/lib.gradle.kts
@@ -153,6 +153,7 @@ dependencies {
     implementation(libs.moshi.adapters)
     implementation(libs.moshi.adapters.lazy)
 
+    implementation(libs.kotlin.immutable.collections)
     implementation(libs.coroutines.core)
 
     implementation(libs.androidx.core)

--- a/lib/src/main/java/com/smileidentity/compose/components/BottomPinnedColumn.kt
+++ b/lib/src/main/java/com/smileidentity/compose/components/BottomPinnedColumn.kt
@@ -2,6 +2,7 @@ package com.smileidentity.compose.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -25,8 +26,8 @@ import com.smileidentity.compose.preview.SmilePreviews
 @SmileIDOptIn
 @Composable
 fun BottomPinnedColumn(
-    scrollableContent: @Composable () -> Unit,
-    pinnedContent: @Composable () -> Unit,
+    scrollableContent: @Composable ColumnScope.() -> Unit,
+    pinnedContent: @Composable ColumnScope.() -> Unit,
     modifier: Modifier = Modifier,
     columnWidth: Dp? = null,
     showDivider: Boolean = false,

--- a/lib/src/main/java/com/smileidentity/compose/consent/bvn/BvnInputScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/bvn/BvnInputScreen.kt
@@ -1,7 +1,5 @@
 package com.smileidentity.compose.consent.bvn
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,15 +12,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -32,17 +29,18 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.smileidentity.R
+import com.smileidentity.compose.components.BottomPinnedColumn
 import com.smileidentity.compose.components.LoadingButton
 import com.smileidentity.compose.preview.Preview
 import com.smileidentity.compose.preview.SmilePreviews
-import com.smileidentity.util.randomUserId
 import com.smileidentity.viewmodel.BvnConsentViewModel
 import com.smileidentity.viewmodel.viewModelFactory
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun BvnInputScreen(
+    userId: String,
     modifier: Modifier = Modifier,
-    userId: String = rememberSaveable { randomUserId() },
     viewModel: BvnConsentViewModel = viewModel(
         factory = viewModelFactory {
             BvnConsentViewModel(userId = userId)
@@ -52,74 +50,64 @@ internal fun BvnInputScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val focusRequester = remember { FocusRequester() }
 
-    Column(
+    BottomPinnedColumn(
         modifier = modifier
             .fillMaxSize()
             .imePadding()
-            .padding(24.dp),
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+            .padding(16.dp),
+        scrollableContent = {
             Text(
                 text = stringResource(id = R.string.si_bvn_enter_bvn_number),
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.ExtraBold,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.fillMaxWidth(),
             )
-        }
-        Spacer(modifier = Modifier.height(36.dp))
-        Text(
-            text = stringResource(id = R.string.si_bvn_enter_id_bank_verification),
-            style = MaterialTheme.typography.titleMedium,
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        OutlinedTextField(
-            value = viewModel.bvnNumber,
-            onValueChange = viewModel::updateBvnNumber,
-            isError = uiState.showError,
-            singleLine = true,
-            modifier = Modifier
-                .fillMaxWidth()
-                .focusRequester(focusRequester),
-            keyboardOptions = KeyboardOptions(
-                imeAction = ImeAction.Done,
-                keyboardType = KeyboardType.NumberPassword,
-            ),
-            keyboardActions = KeyboardActions(
-                onDone = { viewModel.submitUserBvn() },
-            ),
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = stringResource(
-                id = if (uiState.showError) {
-                    R.string.si_bvn_enter_id_wrong_bvn
-                } else {
-                    R.string.si_bvn_enter_bvn_number_limit
+            Spacer(modifier = Modifier.height(36.dp))
+            Text(text = stringResource(id = R.string.si_bvn_enter_id_bank_verification))
+            Spacer(modifier = Modifier.height(16.dp))
+            OutlinedTextField(
+                value = viewModel.bvnNumber,
+                onValueChange = viewModel::updateBvnNumber,
+                isError = uiState.showError,
+                singleLine = true,
+                label = { Text(text = stringResource(id = R.string.si_bvn_acronym)) },
+                supportingText = {
+                    val id = if (uiState.showError) {
+                        R.string.si_bvn_enter_id_wrong_bvn
+                    } else {
+                        R.string.si_bvn_enter_bvn_number_limit
+                    }
+                    Text(text = stringResource(id = id))
                 },
-            ),
-            style = MaterialTheme.typography.bodyMedium,
-            textAlign = TextAlign.Center,
-            color = colorResource(
-                id = if (uiState.showError) {
-                    R.color.si_color_error
-                } else {
-                    R.color.si_color_material_on_primary_container
-                },
-            ),
-        )
-        Spacer(modifier = Modifier.height(56.dp))
-        LoadingButton(
-            buttonText = stringResource(id = R.string.si_continue),
-            loading = uiState.showLoading,
-            enabled = uiState.isBvnValid,
-            onClick = viewModel::submitUserBvn,
-            modifier = Modifier
-                .testTag("bvn_submit_continue_button")
-                .fillMaxWidth(),
-        )
+                keyboardOptions = KeyboardOptions(
+                    imeAction = if (uiState.isBvnValid) ImeAction.Send else ImeAction.None,
+                    // Use NumberPassword instead of Number to prevent entering '.' or ','
+                    keyboardType = KeyboardType.NumberPassword,
+                ),
+                keyboardActions = KeyboardActions(
+                    onSend = { viewModel.submitUserBvn() },
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+            )
+        },
+        pinnedContent = {
+            LoadingButton(
+                buttonText = stringResource(id = R.string.si_continue),
+                loading = uiState.showLoading,
+                enabled = uiState.isBvnValid,
+                onClick = viewModel::submitUserBvn,
+                modifier = Modifier
+                    .testTag("bvn_submit_continue_button")
+                    .fillMaxWidth(),
+            )
+        },
+    )
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
     }
 }
 
@@ -127,6 +115,6 @@ internal fun BvnInputScreen(
 @Composable
 private fun BvnInputScreenPreview() {
     Preview {
-        BvnInputScreen()
+        BvnInputScreen(userId = "")
     }
 }

--- a/lib/src/main/java/com/smileidentity/compose/consent/bvn/ChooseOtpDeliveryScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/bvn/ChooseOtpDeliveryScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -20,9 +21,6 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -43,9 +41,9 @@ import com.smileidentity.compose.components.LoadingButton
 import com.smileidentity.compose.components.annotatedStringResource
 import com.smileidentity.compose.preview.Preview
 import com.smileidentity.compose.preview.SmilePreviews
-import com.smileidentity.util.randomUserId
 import com.smileidentity.viewmodel.BvnConsentViewModel
 import com.smileidentity.viewmodel.viewModelFactory
+import kotlinx.collections.immutable.ImmutableList
 
 internal data class BvnOtpVerificationMode(
     val mode: String,
@@ -56,8 +54,8 @@ internal data class BvnOtpVerificationMode(
 
 @Composable
 internal fun ChooseOtpDeliveryScreen(
+    userId: String,
     modifier: Modifier = Modifier,
-    userId: String = rememberSaveable { randomUserId() },
     viewModel: BvnConsentViewModel = viewModel(
         factory = viewModelFactory {
             BvnConsentViewModel(userId = userId)
@@ -66,12 +64,11 @@ internal fun ChooseOtpDeliveryScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    var canRequestBvnTotp by rememberSaveable { mutableStateOf(false) }
-
     BottomPinnedColumn(
         modifier = modifier
             .fillMaxSize()
-            .padding(24.dp),
+            .padding(16.dp)
+            .imePadding(),
         scrollableContent = {
             Text(
                 text = stringResource(id = R.string.si_bvn_select_contact_method),
@@ -101,20 +98,17 @@ internal fun ChooseOtpDeliveryScreen(
                 style = MaterialTheme.typography.bodyMedium,
             )
             Spacer(modifier = Modifier.height(32.dp))
-            ContactMethod(
-                bvnVerificationMode = uiState.bvnVerificationModes,
+            ContactMethods(
+                bvnVerificationModes = uiState.bvnVerificationModes,
                 selectedBvnOtpVerificationMode = uiState.selectedBvnOtpVerificationMode,
-                onClick = {
-                    viewModel.updateMode(it)
-                    canRequestBvnTotp = true
-                },
+                onClick = viewModel::updateMode,
             )
         },
         pinnedContent = {
             LoadingButton(
                 buttonText = stringResource(id = R.string.si_continue),
                 loading = uiState.showLoading,
-                enabled = canRequestBvnTotp,
+                enabled = uiState.selectedBvnOtpVerificationMode != null,
                 onClick = viewModel::requestBvnOtp,
                 modifier = Modifier
                     .testTag("choose_otp_delivery_continue_button")
@@ -125,19 +119,19 @@ internal fun ChooseOtpDeliveryScreen(
 }
 
 @Composable
-internal fun ContactMethod(
-    bvnVerificationMode: List<BvnOtpVerificationMode>,
+internal fun ContactMethods(
+    bvnVerificationModes: ImmutableList<BvnOtpVerificationMode>,
     selectedBvnOtpVerificationMode: BvnOtpVerificationMode?,
     modifier: Modifier = Modifier,
     onClick: (BvnOtpVerificationMode) -> Unit,
 ) {
-    bvnVerificationMode.forEach {
+    bvnVerificationModes.forEach {
         val selected = selectedBvnOtpVerificationMode == it
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
                 .fillMaxWidth()
-                .padding(vertical = 4.dp)
+                .padding(4.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .background(MaterialTheme.colorScheme.surface)
                 .selectable(
@@ -173,6 +167,6 @@ internal fun ContactMethod(
 @Composable
 private fun ChooseOtpDeliveryScreenPreview() {
     Preview {
-        ChooseOtpDeliveryScreen()
+        ChooseOtpDeliveryScreen(userId = "")
     }
 }

--- a/lib/src/main/java/com/smileidentity/compose/consent/bvn/OrchestratedBvnConsentScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/bvn/OrchestratedBvnConsentScreen.kt
@@ -2,28 +2,29 @@ package com.smileidentity.compose.consent.bvn
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.smileidentity.util.randomUserId
 import com.smileidentity.viewmodel.BvnConsentScreens
 import com.smileidentity.viewmodel.BvnConsentViewModel
 import com.smileidentity.viewmodel.viewModelFactory
 
 @Composable
 internal fun OrchestratedBvnConsentScreen(
-    successfulBvnVerification: () -> Unit,
-    userId: String = rememberSaveable { randomUserId() },
+    userId: String,
     viewModel: BvnConsentViewModel = viewModel(
         factory = viewModelFactory {
             BvnConsentViewModel(userId = userId)
         },
     ),
+    successfulBvnVerification: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     when (uiState.bvnConsentScreens) {
-        BvnConsentScreens.BvnInputScreen -> BvnInputScreen()
-        BvnConsentScreens.ChooseOtpDeliveryScreen -> ChooseOtpDeliveryScreen()
-        BvnConsentScreens.ShowVerifyOtpScreen -> ShowVerifyOtpScreen(successfulBvnVerification)
+        BvnConsentScreens.BvnInputScreen -> BvnInputScreen(userId = userId)
+        BvnConsentScreens.ChooseOtpDeliveryScreen -> ChooseOtpDeliveryScreen(userId = userId)
+        BvnConsentScreens.VerifyOtpScreen -> VerifyOtpScreen(
+            userId = userId,
+            successfulBvnVerification = successfulBvnVerification,
+        )
     }
 }

--- a/lib/src/main/java/com/smileidentity/models/Models.kt
+++ b/lib/src/main/java/com/smileidentity/models/Models.kt
@@ -53,6 +53,6 @@ enum class JobType(val value: Int) {
 
     companion object {
         @JvmStatic
-        fun fromValue(value: Int): JobType = values().find { it.value == value } ?: Unknown
+        fun fromValue(value: Int): JobType = entries.find { it.value == value } ?: Unknown
     }
 }

--- a/lib/src/main/java/com/smileidentity/util/Util.kt
+++ b/lib/src/main/java/com/smileidentity/util/Util.kt
@@ -31,6 +31,7 @@ import com.smileidentity.SmileIDCrashReporting
 import com.smileidentity.compose.consent.bvn.BvnOtpVerificationMode
 import com.smileidentity.models.BvnVerificationMode
 import com.smileidentity.models.SmileIDException
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineExceptionHandler
 import retrofit2.HttpException
 import timber.log.Timber
@@ -38,46 +39,28 @@ import java.io.File
 import java.io.Serializable
 import java.nio.ByteBuffer
 
-internal fun createBvnOtpVerificationModes(maps: List<BvnVerificationMode>):
-    List<BvnOtpVerificationMode> {
-    val verificationModes = mutableListOf<BvnOtpVerificationMode>()
-
-    for (map in maps) {
-        val modeEntry = map.entries.firstOrNull() // Assuming there's only one entry in each map
-        modeEntry?.let { entry ->
-            val mode = entry.key
-            val value = entry.value
-
-            val descriptionRes = when (mode) {
-                "sms" -> R.string.si_bvn_sms_verification
-                "email" -> R.string.si_bvn_email_verification
-                else -> R.string.si_bvn_sms_verification
-            }
-
-            val iconRes = when (mode) {
-                "sms" -> R.drawable.si_bvn_mode_sms
-                "email" -> R.drawable.si_bvn_mode_email
-                else -> R.drawable.si_bvn_mode_sms
-            }
-
-            val otpSentBy = when (mode) {
+internal fun createBvnOtpVerificationModes(maps: List<BvnVerificationMode>) = maps.flatMap {
+    it.entries.map { (mode, value) ->
+        BvnOtpVerificationMode(
+            mode = value,
+            otpSentBy = when (mode) {
                 "sms" -> "sms"
                 "email" -> "email"
                 else -> ""
-            }
-
-            val verificationMode = BvnOtpVerificationMode(
-                mode = value,
-                otpSentBy = otpSentBy,
-                description = descriptionRes,
-                icon = iconRes,
-            )
-            verificationModes.add(verificationMode)
-        }
+            },
+            description = when (mode) {
+                "sms" -> R.string.si_bvn_sms_verification
+                "email" -> R.string.si_bvn_email_verification
+                else -> R.string.si_bvn_sms_verification
+            },
+            icon = when (mode) {
+                "sms" -> R.drawable.si_bvn_mode_sms
+                "email" -> R.drawable.si_bvn_mode_email
+                else -> R.drawable.si_bvn_mode_sms
+            },
+        )
     }
-
-    return verificationModes
-}
+}.toImmutableList()
 
 internal fun Context.toast(@StringRes message: Int) {
     Toast.makeText(this, message, Toast.LENGTH_LONG).show()

--- a/lib/src/main/java/com/smileidentity/viewmodel/BvnConsentViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/BvnConsentViewModel.kt
@@ -8,22 +8,28 @@ import androidx.lifecycle.viewModelScope
 import com.smileidentity.SmileID
 import com.smileidentity.compose.consent.bvn.BvnOtpVerificationMode
 import com.smileidentity.models.AuthenticationRequest
+import com.smileidentity.models.AuthenticationResponse
 import com.smileidentity.models.BvnTotpModeRequest
 import com.smileidentity.models.BvnTotpRequest
 import com.smileidentity.models.JobType
 import com.smileidentity.models.SubmitBvnTotpRequest
 import com.smileidentity.util.createBvnOtpVerificationModes
 import com.smileidentity.util.getExceptionHandler
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+const val BVN_LENGTH = 11
+const val BVN_OTP_LENGTH = 6
+
 internal enum class BvnConsentScreens {
     BvnInputScreen,
     ChooseOtpDeliveryScreen,
-    ShowVerifyOtpScreen,
+    VerifyOtpScreen,
 }
 
 internal data class BvnConsentUiState(
@@ -35,18 +41,21 @@ internal data class BvnConsentUiState(
     val showError: Boolean = false,
     val showSuccess: Boolean = false,
     val selectedBvnOtpVerificationMode: BvnOtpVerificationMode? = null,
-    val bvnVerificationModes: List<BvnOtpVerificationMode> = listOf(),
+    val bvnVerificationModes: ImmutableList<BvnOtpVerificationMode> = persistentListOf(),
 )
-
-const val bvnNumberLength = 11
-const val bvnOtpLength = 6
 
 internal class BvnConsentViewModel(
     private val userId: String,
 ) : ViewModel() {
-
     private val _uiState = MutableStateFlow(BvnConsentUiState())
     val uiState = _uiState.asStateFlow()
+
+    private var authResponse: AuthenticationResponse? = null
+
+    private val errorProxy = { e: Throwable ->
+        Timber.e(e)
+        _uiState.update { it.copy(showError = true, showLoading = false) }
+    }
 
     var bvnNumber by mutableStateOf("")
         private set
@@ -54,26 +63,28 @@ internal class BvnConsentViewModel(
     var otp by mutableStateOf("")
         private set
 
-    var otpSentBy by mutableStateOf("")
-        private set
+    init {
+        viewModelScope.launch(getExceptionHandler(errorProxy)) {
+            authResponse = getAuthResponse()
+        }
+    }
 
     internal fun updateBvnNumber(input: String) {
-        if (input.length <= bvnNumberLength) {
-            _uiState.update { it.copy(isBvnValid = input.length == bvnNumberLength) }
+        if (input.length <= BVN_LENGTH) {
+            _uiState.update { it.copy(isBvnValid = input.length == BVN_LENGTH, showError = false) }
             bvnNumber = input
         }
     }
 
     internal fun updateOtp(input: String) {
-        if (input.length <= bvnOtpLength) {
-            _uiState.update { it.copy(isBvnOtpValid = input.length == bvnOtpLength) }
+        if (input.length <= BVN_OTP_LENGTH) {
+            _uiState.update { it.copy(isBvnOtpValid = input.length == BVN_OTP_LENGTH) }
             otp = input
         }
     }
 
     internal fun updateMode(input: BvnOtpVerificationMode) {
         _uiState.update { it.copy(selectedBvnOtpVerificationMode = input) }
-        otpSentBy = input.otpSentBy
         otp = ""
     }
 
@@ -87,22 +98,19 @@ internal class BvnConsentViewModel(
     }
 
     internal fun submitUserBvn() {
-        if (bvnNumber.length != bvnNumberLength) {
+        if (bvnNumber.length != BVN_LENGTH) {
+            Timber.w("State mismatch: bvnNumber.length != BVN_LENGTH")
+            return
+        }
+        if (uiState.value.showLoading) {
+            Timber.w("A request is already in progress")
             return
         }
 
         _uiState.update { it.copy(showLoading = true) }
-        val proxy = { e: Throwable ->
-            Timber.e(e)
-            _uiState.update { it.copy(showError = true, showLoading = false) }
-        }
 
-        viewModelScope.launch(getExceptionHandler(proxy)) {
-            val authRequest = AuthenticationRequest(
-                userId = userId,
-                jobType = JobType.BVN,
-            )
-            val authResponse = SmileID.api.authenticate(authRequest)
+        viewModelScope.launch(getExceptionHandler(errorProxy)) {
+            val authResponse = authResponse ?: getAuthResponse()
             val request = BvnTotpRequest(
                 idNumber = bvnNumber,
                 signature = authResponse.signature,
@@ -122,54 +130,48 @@ internal class BvnConsentViewModel(
     }
 
     internal fun requestBvnOtp() {
-        _uiState.update { it.copy(showLoading = true) }
-        val proxy = { e: Throwable ->
-            Timber.e(e)
-            _uiState.update { it.copy(showLoading = false) }
+        if (uiState.value.showLoading) {
+            Timber.w("A request is already in progress")
+            return
         }
-
-        viewModelScope.launch(getExceptionHandler(proxy)) {
-            val authRequest = AuthenticationRequest(
-                userId = userId,
-                jobType = JobType.BVN,
-            )
-            val authResponse = SmileID.api.authenticate(authRequest)
+        _uiState.update { it.copy(showLoading = true) }
+        viewModelScope.launch(getExceptionHandler(errorProxy)) {
+            val authResponse = authResponse ?: getAuthResponse()
             val request = BvnTotpModeRequest(
                 idNumber = bvnNumber,
-                mode = otpSentBy,
+                mode = uiState.value.selectedBvnOtpVerificationMode?.otpSentBy ?: "",
                 sessionId = uiState.value.sessionId,
                 signature = authResponse.signature,
                 timestamp = authResponse.timestamp,
             )
             val response = SmileID.api.requestBvnOtp(request = request)
-            _uiState.update {
-                it.copy(
-                    bvnConsentScreens = BvnConsentScreens.ShowVerifyOtpScreen,
-                    showLoading = false,
-                )
+            if (response.success) {
+                _uiState.update {
+                    it.copy(
+                        bvnConsentScreens = BvnConsentScreens.VerifyOtpScreen,
+                        showLoading = false,
+                    )
+                }
+            } else {
+                _uiState.update { it.copy(showLoading = false, showError = true) }
             }
         }
     }
 
     internal fun submitBvnOtp() {
-        if (otp.length == bvnOtpLength) {
+        if (otp.length != BVN_OTP_LENGTH) {
+            Timber.w("State mismatch: otp.length != BVN_OTP_LENGTH")
+            return
+        }
+        if (uiState.value.showLoading) {
+            Timber.w("A request is already in progress")
             return
         }
 
         _uiState.update { it.copy(showLoading = true) }
-        val proxy = { e: Throwable ->
-            Timber.e(e)
-            _uiState.update {
-                it.copy(showLoading = false, showError = true)
-            }
-        }
 
-        viewModelScope.launch(getExceptionHandler(proxy)) {
-            val authRequest = AuthenticationRequest(
-                userId = userId,
-                jobType = JobType.BVN,
-            )
-            val authResponse = SmileID.api.authenticate(authRequest)
+        viewModelScope.launch(getExceptionHandler(errorProxy)) {
+            val authResponse = authResponse ?: getAuthResponse()
             val request = SubmitBvnTotpRequest(
                 idNumber = bvnNumber,
                 otp = otp,
@@ -178,7 +180,20 @@ internal class BvnConsentViewModel(
                 timestamp = authResponse.timestamp,
             )
             val response = SmileID.api.submitBvnOtp(request = request)
-            _uiState.update { it.copy(showLoading = false, showSuccess = response.success) }
+            _uiState.update {
+                it.copy(
+                    showLoading = false,
+                    showSuccess = response.success,
+                    showError = !response.success,
+                )
+            }
         }
     }
+
+    private suspend fun getAuthResponse() = SmileID.api.authenticate(
+        AuthenticationRequest(
+            userId = userId,
+            jobType = JobType.BVN,
+        ),
+    )
 }

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="si_bvn_product_name">BVN Consent</string>
     <string name="si_bvn_enter_bvn_number">Enter your BVN Number</string>
     <string name="si_bvn_enter_id_bank_verification">Bank Verification Number</string>
+    <string name="si_bvn_acronym">BVN</string>
     <string name="si_bvn_enter_bvn_number_limit">Your BVN should be 11 digits long</string>
     <string name="si_bvn_enter_id_wrong_bvn">You have entered an invalid BVN. Please try again</string>
     <string name="si_bvn_select_contact_method">Select Contact Method</string>
@@ -144,6 +145,7 @@
     <string name="si_bvn_verification_different_contact_method">Try another contact method</string>
     <string name="si_bvn_verification_invalid_otp">OTP entered is invalid</string>
     <string name="si_bvn_verification_didnt_receive_otp_at">Didn\'t receive the OTP at %1$s?</string>
+    <string name="si_bvn_verification_otp_acronym">OTP</string>
 
     <!--  Generic Errors  -->
     <string name="si_processing_error_subtitle">This could be because of image quality or internet connectivity</string>

--- a/lib/src/test/java/com/smileidentity/networking/JobTypeAdapterTest.kt
+++ b/lib/src/test/java/com/smileidentity/networking/JobTypeAdapterTest.kt
@@ -15,7 +15,7 @@ class JobTypeAdapterTest {
     @Test
     fun `toJson should return the correct value`() {
         // given
-        for (value in JobType.values()) {
+        for (value in JobType.entries) {
             // when
             val result = adapter.toJson(value)
 
@@ -27,7 +27,7 @@ class JobTypeAdapterTest {
     @Test
     fun `fromJson should return the correct value`() {
         // given
-        for (value in JobType.values()) {
+        for (value in JobType.entries) {
             // when
             val result = adapter.fromJson(value.value.toString())
 

--- a/lib/src/test/java/com/smileidentity/viewmodel/BvnConsentViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/BvnConsentViewModelTest.kt
@@ -124,6 +124,7 @@ class BvnConsentViewModelTest {
         )
 
         // when
+        subject.updateOtp("000000")
         subject.submitBvnOtp()
 
         // then

--- a/lib/src/test/java/com/smileidentity/viewmodel/BvnConsentViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/BvnConsentViewModelTest.kt
@@ -100,7 +100,7 @@ class BvnConsentViewModelTest {
 
         // then
         Assert.assertEquals(
-            BvnConsentScreens.ShowVerifyOtpScreen,
+            BvnConsentScreens.VerifyOtpScreen,
             subject.uiState.value.bvnConsentScreens,
         )
     }

--- a/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
@@ -89,8 +89,7 @@ fun MainScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val bottomNavSelection = uiState.bottomNavSelection
 
-    // TODO: Switch to BottomNavigationScreen.entries once we are using Kotlin 1.9
-    val bottomNavItems = remember { BottomNavigationScreen.values().toList().toImmutableList() }
+    val bottomNavItems = remember { BottomNavigationScreen.entries.toImmutableList() }
     // Show up button when not on a BottomNavigationScreen
     val showUpButton = currentRoute?.destination?.route?.let { route ->
         bottomNavItems.none { it.route.contains(route) }
@@ -272,6 +271,7 @@ fun MainScreen(
                 composable(ProductScreen.BvnConsent.route) {
                     LaunchedEffect(Unit) { viewModel.onBvnConsentSelected() }
                     SmileID.BvnConsentScreen {
+                        viewModel.onSuccessfulBvnConsent()
                         navController.popBackStack(
                             route = BottomNavigationScreen.Home.route,
                             inclusive = false,

--- a/sample/src/main/java/com/smileidentity/sample/viewmodel/MainScreenViewModel.kt
+++ b/sample/src/main/java/com/smileidentity/sample/viewmodel/MainScreenViewModel.kt
@@ -440,6 +440,12 @@ class MainScreenViewModel : ViewModel() {
         }
     }
 
+    fun onSuccessfulBvnConsent() {
+        _uiState.update {
+            it.copy(snackbarMessage = SnackbarMessage("BVN Consent Successful"))
+        }
+    }
+
     fun clearJobs() {
         viewModelScope.launch {
             DataStoreRepository.clearJobs(SmileID.config.partnerId, !SmileID.useSandbox)


### PR DESCRIPTION
- Pass userId to the various screens
- Return back to MainScreen on success
- Show Snackbar on success
- Fix some spacing issues
- Use `ImmutableList` instead of `List` for Compose stability
- Auto-show keyboard for BVN and OTP input
- Prevent duplicate network requests
- Moved lambdas to be the last parameter (to encourage trailing lambdas)

Also:
- Moved `Enum.values()` to `Enum.entries`  as per Kotlin 1.9
- Updated CHANGELOG and VERSION for beta08
- Clarify some naming
- Update `BottomPinnedColumn` slots to be in `ColumnScope` so that additional Modifiers can be used by children