### PR TITLE
Expose Compose Material 3 as an `api` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Dependency on `org.jetbrains.kotlinx:kotlinx-collections-immutable`
 
 ### Fixed
+- Expose Compose Material 3 as an `api` dependency 
 
 ### Changed
 - Bump Sentry to 6.29.0

--- a/lib/lib.gradle.kts
+++ b/lib/lib.gradle.kts
@@ -180,8 +180,8 @@ dependencies {
     androidTestImplementation(composeBom)
     lintChecks(libs.compose.lint.checks)
 
-    // Material Design 3 components
-    implementation(libs.androidx.compose.material3)
+    // Material Design components (ColorScheme and Typography exposed, hence api vs implementation)
+    api(libs.androidx.compose.material3)
     // Jetpack Compose UI
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.text.google.fonts)


### PR DESCRIPTION
Material 3's `ColorScheme` and `Typography` are exposed in our public interface, so it needs to be exposed as an `api` dependency instead of `implementation` so that a fresh project doesn't run into build issues