### PR TITLE
Remove `filename` property from `PrepUploadRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bump Sentry to 6.29.0
 
 ### Removed
+- `filename` property from `PrepUploadRequest`, as it is no longer required
 
 ## 10.0.0-beta07
 

--- a/lib/src/main/java/com/smileidentity/models/PrepUpload.kt
+++ b/lib/src/main/java/com/smileidentity/models/PrepUpload.kt
@@ -10,9 +10,6 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class PrepUploadRequest(
-    // This filename is largely irrelevant, it is just the name created on S3. No correlation
-    // with the file name on the device's filesystem.
-    @Json(name = "file_name") val filename: String = "upload.zip",
     @Json(name = "partner_params") val partnerParams: PartnerParams,
     @Json(name = "model_parameters") val modelParameters: Map<String, Any> = mapOf(),
     // Callback URL *must* be defined either within your Partner Portal or here


### PR DESCRIPTION
## Summary

Removes the `file_name` from prep upload, as it is no longer required
