### PR TITLE
Enforce orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - Renamed `JobResult.Entry` to `SmartSelfieJobResult.Entry`
   - Renamed `BiometricKycEntry` to `BiometricKycJobResult.Entry`
   - `JobResult.Entry` is now an interface for all job types
+- Enforce portrait orientation
 
 ### Removed
 - `filename` property from `PrepUploadRequest`, as it is no longer required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - Renamed `BiometricKycEntry` to `BiometricKycJobResult.Entry`
   - `JobResult.Entry` is now an interface for all job types
 - Enforce portrait orientation
+- Set brightness to maximum only on selfies, but not for Agent Mode
 
 ### Removed
 - `filename` property from `PrepUploadRequest`, as it is no longer required

--- a/lib/src/main/java/com/smileidentity/compose/components/ActivityComposables.kt
+++ b/lib/src/main/java/com/smileidentity/compose/components/ActivityComposables.kt
@@ -24,6 +24,21 @@ fun ForceBrightness(brightness: Float = 1f) {
     }
 }
 
+/**
+ * Locks the screen orientation to a given orientation and reverts after exiting screen
+ *
+ * @param orientation One of the [ActivityInfo.SCREEN_ORIENTATION_*] constants
+ */
+@Composable
+fun ForceOrientation(orientation: Int) {
+    val activity = LocalContext.current.getActivity() ?: return
+    DisposableEffect(Unit) {
+        val originalOrientation = activity.requestedOrientation
+        activity.requestedOrientation = orientation
+        onDispose { activity.requestedOrientation = originalOrientation }
+    }
+}
+
 private fun Context.getActivity(): Activity? {
     var context = this
     while (context is ContextWrapper) {

--- a/lib/src/main/java/com/smileidentity/compose/consent/bvn/OrchestratedBvnConsentScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/bvn/OrchestratedBvnConsentScreen.kt
@@ -1,9 +1,11 @@
 package com.smileidentity.compose.consent.bvn
 
+import android.content.pm.ActivityInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.smileidentity.compose.components.ForceOrientation
 import com.smileidentity.viewmodel.BvnConsentScreens
 import com.smileidentity.viewmodel.BvnConsentViewModel
 import com.smileidentity.viewmodel.viewModelFactory
@@ -18,6 +20,7 @@ internal fun OrchestratedBvnConsentScreen(
     ),
     successfulBvnVerification: () -> Unit,
 ) {
+    ForceOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     when (uiState.bvnConsentScreens) {
         BvnConsentScreens.BvnInputScreen -> BvnInputScreen(userId = userId)

--- a/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
@@ -1,5 +1,6 @@
 package com.smileidentity.compose.document
 
+import android.content.pm.ActivityInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -8,6 +9,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.smileidentity.R
+import com.smileidentity.compose.components.ForceOrientation
 import com.smileidentity.compose.components.ProcessingScreen
 import com.smileidentity.compose.selfie.OrchestratedSelfieCaptureScreen
 import com.smileidentity.models.Document
@@ -49,6 +51,7 @@ internal fun OrchestratedDocumentVerificationScreen(
     ),
     onResult: SmileIDCallback<DocumentVerificationResult> = {},
 ) {
+    ForceOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     when (val currentStep = uiState.currentStep) {
         DocumentCaptureFlow.FrontDocumentCapture -> DocumentCaptureScreen(

--- a/lib/src/main/java/com/smileidentity/compose/selfie/OrchestratedSelfieCaptureScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/selfie/OrchestratedSelfieCaptureScreen.kt
@@ -1,5 +1,6 @@
 package com.smileidentity.compose.selfie
 
+import android.content.pm.ActivityInfo
 import android.graphics.BitmapFactory
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -13,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.smileidentity.R
+import com.smileidentity.compose.components.ForceOrientation
 import com.smileidentity.compose.components.ImageCaptureConfirmationDialog
 import com.smileidentity.compose.components.ProcessingScreen
 import com.smileidentity.results.SmartSelfieResult
@@ -40,6 +42,7 @@ internal fun OrchestratedSelfieCaptureScreen(
     ),
     onResult: SmileIDCallback<SmartSelfieResult> = {},
 ) {
+    ForceOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     var acknowledgedInstructions by rememberSaveable { mutableStateOf(false) }
     when {

--- a/lib/src/main/java/com/smileidentity/compose/selfie/SelfieCaptureScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/selfie/SelfieCaptureScreen.kt
@@ -68,8 +68,10 @@ internal fun SelfieCaptureScreen(
     var camSelector by rememberCamSelector(CamSelector.Front)
     val viewfinderZoom = 1.1f
     val faceFillPercent = remember { MAX_FACE_AREA_THRESHOLD * viewfinderZoom * 2 }
-    // Force maximum brightness in order to light up the user's face
-    ForceBrightness()
+    if (camSelector == CamSelector.Front) {
+        // Force maximum brightness in order to light up the user's face
+        ForceBrightness()
+    }
     Box(modifier = Modifier.fillMaxSize()) {
         CameraPreview(
             cameraState = cameraState,


### PR DESCRIPTION
## Summary

- Enforce portrait mode
- Set brightness to max only when using front camera, as doing so serves no purpose when using back camera