### PR TITLE
Show Consent Screen as part of BVN Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 10.0.0-beta09 (unreleased)
+
+### Added
+
+### Fixed
+- Updated KDocs with missing parameter descriptions
+
+### Changed
+- Show the normal consent screen as part of BVN Verification
+- The parameters of BvnConsentScreen have been updated to support inclusion of the consent screen
+
+### Removed
+
 ## 10.0.0-beta08
 
 ### Added

--- a/lib/VERSION
+++ b/lib/VERSION
@@ -1,1 +1,1 @@
-10.0.0-beta08-SNAPSHOT
+10.0.0-beta09-SNAPSHOT

--- a/lib/src/androidTest/java/com/smileidentity/compose/consent/OrchestratedConsentScreenTest.kt
+++ b/lib/src/androidTest/java/com/smileidentity/compose/consent/OrchestratedConsentScreenTest.kt
@@ -1,0 +1,119 @@
+package com.smileidentity.compose.consent
+
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.smileidentity.R
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.net.URL
+
+class OrchestratedConsentScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun shouldShowConsentScreenInitially() {
+        // when
+        composeTestRule.setContent {
+            OrchestratedConsentScreen(
+                partnerIcon = painterResource(id = R.drawable.si_logo_with_text),
+                partnerName = "Smile ID",
+                productName = "BVN",
+                partnerPrivacyPolicy = URL("https://usesmileid.com/privacy"),
+                onConsentGranted = {},
+                onConsentDenied = {},
+            )
+        }
+
+        // then
+        composeTestRule.onNodeWithTag("consent_screen").assertExists()
+    }
+
+    @Test
+    fun shouldInvokeConsentGrantedCallback() {
+        // given
+        var callbackInvoked = false
+
+        // when
+        composeTestRule.setContent {
+            OrchestratedConsentScreen(
+                partnerIcon = painterResource(id = R.drawable.si_logo_with_text),
+                partnerName = "Smile ID",
+                productName = "BVN",
+                partnerPrivacyPolicy = URL("https://usesmileid.com/privacy"),
+                onConsentGranted = { callbackInvoked = true },
+                onConsentDenied = {},
+            )
+        }
+        composeTestRule.onNodeWithText("Allow").performClick()
+
+        // then
+        assertTrue(callbackInvoked)
+    }
+
+    @Test
+    fun shouldShowConsentDeniedScreen() {
+        // when
+        composeTestRule.setContent {
+            OrchestratedConsentScreen(
+                partnerIcon = painterResource(id = R.drawable.si_logo_with_text),
+                partnerName = "Smile ID",
+                productName = "BVN",
+                partnerPrivacyPolicy = URL("https://usesmileid.com/privacy"),
+                onConsentGranted = {},
+                onConsentDenied = {},
+            )
+        }
+        composeTestRule.onNodeWithText("Cancel").performClick()
+
+        // then
+        composeTestRule.onNodeWithTag("consent_denied_screen").assertExists()
+    }
+
+    @Test
+    fun shouldGoBackFromConsentDeniedScreen() {
+        // when
+        composeTestRule.setContent {
+            OrchestratedConsentScreen(
+                partnerIcon = painterResource(id = R.drawable.si_logo_with_text),
+                partnerName = "Smile ID",
+                productName = "BVN",
+                partnerPrivacyPolicy = URL("https://usesmileid.com/privacy"),
+                onConsentGranted = {},
+                onConsentDenied = {},
+            )
+        }
+        composeTestRule.onNodeWithText("Cancel").performClick()
+        composeTestRule.onNodeWithText("Yes, go back").performClick()
+
+        // then
+        composeTestRule.onNodeWithTag("consent_screen").assertExists()
+    }
+
+    @Test
+    fun shouldInvokeConsentDeniedCallback() {
+        // given
+        var callbackInvoked = false
+
+        // when
+        composeTestRule.setContent {
+            OrchestratedConsentScreen(
+                partnerIcon = painterResource(id = R.drawable.si_logo_with_text),
+                partnerName = "Smile ID",
+                productName = "BVN",
+                partnerPrivacyPolicy = URL("https://usesmileid.com/privacy"),
+                onConsentGranted = {},
+                onConsentDenied = { callbackInvoked = true },
+            )
+        }
+        composeTestRule.onNodeWithText("Cancel").performClick()
+        composeTestRule.onNodeWithText("No, cancel verification").performClick()
+
+        // then
+        assertTrue(callbackInvoked)
+    }
+}

--- a/lib/src/androidTest/java/com/smileidentity/compose/document/DocumentCaptureScreenTest.kt
+++ b/lib/src/androidTest/java/com/smileidentity/compose/document/DocumentCaptureScreenTest.kt
@@ -47,6 +47,7 @@ class DocumentCaptureScreenTest {
                 knownIdAspectRatio = null,
                 onConfirm = {},
                 onError = {},
+                showSkipButton = true,
             )
         }
 
@@ -77,6 +78,7 @@ class DocumentCaptureScreenTest {
                 knownIdAspectRatio = null,
                 onConfirm = {},
                 onError = {},
+                showSkipButton = true,
             )
         }
 

--- a/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
+++ b/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
@@ -187,6 +187,10 @@ fun SmileID.DocumentVerification(
  * [Docs](https://docs.usesmileid.com/products/for-individuals-kyc/biometric-kyc)
  *
  * @param idInfo The ID information to look up in the ID Authority
+ * @param partnerIcon Your own icon to display on the Biometric KYC screen (i.e. company logo)
+ * @param partnerName Your own name to display on the Biometric KYC screen (i.e. company name)
+ * @param productName The type of information you are trying to access (i.e. ID type)
+ * @param partnerPrivacyPolicy A link to your own privacy policy to display
  * @param userId The user ID to associate with the Biometric KYC. Most often, this will correspond
  * to a unique User ID within your own system. If not provided, a random user ID will be generated
  * @param jobId The job ID to associate with the Biometric KYC. Most often, this will correspond
@@ -233,24 +237,39 @@ fun SmileID.BiometricKYC(
 }
 
 /**
- * Perform BVN verification: Verify the BVN information of your user and confirm that the ID actually
- * belongs to the user.
+ * Perform BVN verification: Verify the BVN information of your user and confirm that the ID
+ * actually belongs to the user by requesting an OTP.
  *
  * [Docs](https://docs.usesmileid.com/integration-options/mobile/android/consent-screen#bvn-consent-screen)
  *
+ * @param partnerIcon Your own icon to display on the BVN Consent screen (i.e. company logo)
+ * @param partnerName Your own name to display on the BVN Consent screen (i.e. company name)
+ * @param partnerPrivacyPolicy A link to your own privacy policy to display
  * @param userId The user ID to associate with the BVN Job. Most often, this will correspond
  * to a unique User ID within your own system. If not provided, a random user ID will be generated
- * @param onSuccessfulBvnVerification Callback to be invoked when the BVN verification job is complete.
+ * @param onConsentDenied Callback to be invoked when the user denies consent to BVN verification.
+ * @param onConsentGranted Callback to be invoked when the BVN verification job is
+ * complete.
  */
 @Composable
 fun SmileID.BvnConsentScreen(
+    partnerIcon: Painter,
+    partnerName: String,
+    partnerPrivacyPolicy: URL,
+    onConsentGranted: () -> Unit,
+    onConsentDenied: () -> Unit,
+    showAttribution: Boolean = true,
     userId: String = rememberSaveable { randomUserId() },
-    onSuccessfulBvnVerification: () -> Unit,
 ) {
     MaterialTheme(colorScheme = colorScheme, typography = typography) {
         OrchestratedBvnConsentScreen(
             userId = userId,
-            successfulBvnVerification = onSuccessfulBvnVerification,
+            partnerIcon = partnerIcon,
+            partnerName = partnerName,
+            partnerPrivacyPolicy = partnerPrivacyPolicy,
+            onConsentGranted = onConsentGranted,
+            onConsentDenied = onConsentDenied,
+            showAttribution = showAttribution,
         )
     }
 }

--- a/lib/src/main/java/com/smileidentity/compose/biometric/OrchestratedBiometricKYCScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/biometric/OrchestratedBiometricKYCScreen.kt
@@ -15,8 +15,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.smileidentity.R
 import com.smileidentity.compose.components.ProcessingScreen
-import com.smileidentity.compose.consent.ConsentDeniedScreen
-import com.smileidentity.compose.consent.ConsentScreen
+import com.smileidentity.compose.consent.OrchestratedConsentScreen
 import com.smileidentity.compose.selfie.OrchestratedSelfieCaptureScreen
 import com.smileidentity.models.IdInfo
 import com.smileidentity.results.BiometricKycResult
@@ -52,19 +51,15 @@ fun OrchestratedBiometricKYCScreen(
             CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
         }
 
-        uiState.showConsent -> ConsentScreen(
+        uiState.showConsent -> OrchestratedConsentScreen(
             partnerIcon = partnerIcon,
             partnerName = partnerName,
             productName = productName,
             partnerPrivacyPolicy = partnerPrivacyPolicy,
             showAttribution = showAttribution,
-            onContinue = { viewModel.onConsentGranted() },
-            onCancel = { viewModel.onConsentDenied() },
-        )
-
-        uiState.consentDenied -> ConsentDeniedScreen(
-            onGoBack = { viewModel.onConsentDeniedTryAgain() },
-            onCancel = {
+            modifier = modifier,
+            onConsentGranted = viewModel::onConsentGranted,
+            onConsentDenied = {
                 onResult(SmileIDResult.Error(OperationCanceledException("User did not consent")))
             },
         )

--- a/lib/src/main/java/com/smileidentity/compose/components/ProcessingScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/components/ProcessingScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -42,6 +43,11 @@ enum class ProcessingState {
 /**
  * This screen represents a generic Processing state. It has 3 sub-states: In Progress, Success, and
  * Error. These sub-states are represented by the [processingState] parameter.
+ *
+ * Note: because we accept [Painter] for the icons, this may cause some extra recompositions.
+ * However, this is done so that partners can have the flexibility to replace icons with normal
+ * images, if they so choose (as opposed to an optimization where we accept only [ImageVector],
+ * which is immutable)
  *
  * @param processingState The state of the processing.
  * @param inProgressTitle The title to display when the processing is in progress.

--- a/lib/src/main/java/com/smileidentity/compose/consent/ConsentDeniedScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/ConsentDeniedScreen.kt
@@ -83,7 +83,7 @@ internal fun ConsentDeniedScreen(
                 SmileIDAttribution()
             }
         },
-        modifier = modifier,
+        modifier = modifier.testTag("consent_denied_screen"),
     )
 }
 

--- a/lib/src/main/java/com/smileidentity/compose/consent/ConsentScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/ConsentScreen.kt
@@ -157,7 +157,7 @@ internal fun ConsentScreen(
                 SmileIDAttribution()
             }
         },
-        modifier = modifier,
+        modifier = modifier.testTag("consent_screen"),
         showDivider = true,
     )
 }

--- a/lib/src/main/java/com/smileidentity/compose/consent/OrchestratedConsentScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/OrchestratedConsentScreen.kt
@@ -1,0 +1,44 @@
+package com.smileidentity.compose.consent
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import java.net.URL
+
+/**
+ * Responsible for showing the consent screen and the consent denied (try again) screens.
+ */
+@Composable
+internal fun OrchestratedConsentScreen(
+    partnerIcon: Painter,
+    partnerName: String,
+    productName: String,
+    partnerPrivacyPolicy: URL,
+    onConsentGranted: () -> Unit,
+    onConsentDenied: () -> Unit,
+    modifier: Modifier = Modifier,
+    showAttribution: Boolean = true,
+) {
+    var showTryAgain by remember { mutableStateOf(false) }
+    when {
+        showTryAgain -> ConsentDeniedScreen(
+            onGoBack = { showTryAgain = false },
+            onCancel = onConsentDenied,
+            modifier = modifier,
+        )
+        else -> ConsentScreen(
+            partnerIcon = partnerIcon,
+            partnerName = partnerName,
+            productName = productName,
+            partnerPrivacyPolicy = partnerPrivacyPolicy,
+            showAttribution = showAttribution,
+            modifier = modifier,
+            onContinue = onConsentGranted,
+            onCancel = { showTryAgain = true },
+        )
+    }
+}

--- a/lib/src/main/java/com/smileidentity/compose/consent/OrchestratedConsentScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/OrchestratedConsentScreen.kt
@@ -24,13 +24,14 @@ internal fun OrchestratedConsentScreen(
     showAttribution: Boolean = true,
 ) {
     var showTryAgain by remember { mutableStateOf(false) }
-    when {
-        showTryAgain -> ConsentDeniedScreen(
+    if (showTryAgain) {
+        ConsentDeniedScreen(
             onGoBack = { showTryAgain = false },
             onCancel = onConsentDenied,
             modifier = modifier,
         )
-        else -> ConsentScreen(
+    } else {
+        ConsentScreen(
             partnerIcon = partnerIcon,
             partnerName = partnerName,
             productName = productName,

--- a/lib/src/main/java/com/smileidentity/compose/consent/bvn/OrchestratedBvnConsentScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/bvn/OrchestratedBvnConsentScreen.kt
@@ -2,29 +2,46 @@ package com.smileidentity.compose.consent.bvn
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.smileidentity.compose.consent.OrchestratedConsentScreen
 import com.smileidentity.viewmodel.BvnConsentScreens
 import com.smileidentity.viewmodel.BvnConsentViewModel
 import com.smileidentity.viewmodel.viewModelFactory
+import java.net.URL
 
 @Composable
 internal fun OrchestratedBvnConsentScreen(
     userId: String,
+    partnerIcon: Painter,
+    partnerName: String,
+    partnerPrivacyPolicy: URL,
+    onConsentGranted: () -> Unit,
+    onConsentDenied: () -> Unit,
+    showAttribution: Boolean = true,
     viewModel: BvnConsentViewModel = viewModel(
         factory = viewModelFactory {
             BvnConsentViewModel(userId = userId)
         },
     ),
-    successfulBvnVerification: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    when (uiState.bvnConsentScreens) {
+    when (uiState.currentScreen) {
+        BvnConsentScreens.ConsentScreen -> OrchestratedConsentScreen(
+            partnerIcon = partnerIcon,
+            partnerName = partnerName,
+            productName = "BVN",
+            partnerPrivacyPolicy = partnerPrivacyPolicy,
+            showAttribution = showAttribution,
+            onConsentGranted = viewModel::onConsentGranted,
+            onConsentDenied = onConsentDenied,
+        )
         BvnConsentScreens.BvnInputScreen -> BvnInputScreen(userId = userId)
         BvnConsentScreens.ChooseOtpDeliveryScreen -> ChooseOtpDeliveryScreen(userId = userId)
         BvnConsentScreens.VerifyOtpScreen -> VerifyOtpScreen(
             userId = userId,
-            successfulBvnVerification = successfulBvnVerification,
+            onSuccessfulBvnVerification = onConsentGranted,
         )
     }
 }

--- a/lib/src/main/java/com/smileidentity/compose/consent/bvn/VerifyOtpScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/bvn/VerifyOtpScreen.kt
@@ -47,10 +47,10 @@ internal fun VerifyOtpScreen(
             BvnConsentViewModel(userId = userId)
         },
     ),
-    successfulBvnVerification: () -> Unit,
+    onSuccessfulBvnVerification: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    if (uiState.showSuccess) successfulBvnVerification()
+    if (uiState.showSuccess) onSuccessfulBvnVerification()
 
     val focusRequester = remember { FocusRequester() }
 

--- a/lib/src/main/java/com/smileidentity/viewmodel/BiometricKycViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/BiometricKycViewModel.kt
@@ -26,7 +26,6 @@ import java.io.File
 data class BiometricKycUiState(
     val showLoading: Boolean = true,
     val showConsent: Boolean = false,
-    val consentDenied: Boolean = false,
     val processingState: ProcessingState? = null,
 )
 
@@ -67,15 +66,7 @@ class BiometricKycViewModel(
     }
 
     fun onConsentGranted() {
-        _uiState.update { it.copy(showConsent = false, consentDenied = false) }
-    }
-
-    fun onConsentDenied() {
-        _uiState.update { it.copy(showConsent = false, consentDenied = true) }
-    }
-
-    fun onConsentDeniedTryAgain() {
-        _uiState.update { it.copy(showConsent = true, consentDenied = false) }
+        _uiState.update { it.copy(showConsent = false) }
     }
 
     fun onSelfieCaptured(selfieFile: File, livenessFiles: List<File>) {

--- a/lib/src/main/java/com/smileidentity/viewmodel/BvnConsentViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/BvnConsentViewModel.kt
@@ -27,13 +27,14 @@ const val BVN_LENGTH = 11
 const val BVN_OTP_LENGTH = 6
 
 internal enum class BvnConsentScreens {
+    ConsentScreen,
     BvnInputScreen,
     ChooseOtpDeliveryScreen,
     VerifyOtpScreen,
 }
 
 internal data class BvnConsentUiState(
-    val bvnConsentScreens: BvnConsentScreens = BvnConsentScreens.BvnInputScreen,
+    val currentScreen: BvnConsentScreens = BvnConsentScreens.ConsentScreen,
     val isBvnValid: Boolean = false,
     val isBvnOtpValid: Boolean = false,
     val sessionId: String = "",
@@ -69,6 +70,10 @@ internal class BvnConsentViewModel(
         }
     }
 
+    fun onConsentGranted() {
+        _uiState.update { it.copy(currentScreen = BvnConsentScreens.BvnInputScreen) }
+    }
+
     internal fun updateBvnNumber(input: String) {
         if (input.length <= BVN_LENGTH) {
             _uiState.update { it.copy(isBvnValid = input.length == BVN_LENGTH, showError = false) }
@@ -91,7 +96,7 @@ internal class BvnConsentViewModel(
     internal fun selectContactMethod() {
         _uiState.update {
             it.copy(
-                bvnConsentScreens = BvnConsentScreens.ChooseOtpDeliveryScreen,
+                currentScreen = BvnConsentScreens.ChooseOtpDeliveryScreen,
                 showError = false,
             )
         }
@@ -119,7 +124,7 @@ internal class BvnConsentViewModel(
             val response = SmileID.api.requestBvnTotpMode(request = request)
             _uiState.update {
                 it.copy(
-                    bvnConsentScreens = BvnConsentScreens.ChooseOtpDeliveryScreen,
+                    currentScreen = BvnConsentScreens.ChooseOtpDeliveryScreen,
                     showLoading = false,
                     sessionId = response.sessionId,
                     showError = false,
@@ -148,7 +153,7 @@ internal class BvnConsentViewModel(
             if (response.success) {
                 _uiState.update {
                     it.copy(
-                        bvnConsentScreens = BvnConsentScreens.VerifyOtpScreen,
+                        currentScreen = BvnConsentScreens.VerifyOtpScreen,
                         showLoading = false,
                     )
                 }

--- a/lib/src/test/java/com/smileidentity/viewmodel/BvnConsentViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/BvnConsentViewModelTest.kt
@@ -70,7 +70,7 @@ class BvnConsentViewModelTest {
         // then
         Assert.assertEquals(
             BvnConsentScreens.ChooseOtpDeliveryScreen,
-            subject.uiState.value.bvnConsentScreens,
+            subject.uiState.value.currentScreen,
         )
     }
 
@@ -101,7 +101,7 @@ class BvnConsentViewModelTest {
         // then
         Assert.assertEquals(
             BvnConsentScreens.VerifyOtpScreen,
-            subject.uiState.value.bvnConsentScreens,
+            subject.uiState.value.currentScreen,
         )
     }
 

--- a/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
@@ -442,7 +442,8 @@ private fun Snackbar(viewModel: MainScreenViewModel = viewModel()) {
     val snackbarMessage = viewModel.uiState.collectAsStateWithLifecycle().value.snackbarMessage
 
     LaunchedEffect(snackbarMessage) {
-        snackbarMessage?.let { coroutineScope.launch { snackbarHostState.showSnackbar(it.value) } }
+        snackbarMessage?.let { coroutineScope.launch { snackbarHostState.showSnackbar(it) } }
+        viewModel.clearSnackbar()
     }
 
     SnackbarHost(snackbarHostState) {

--- a/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
@@ -79,6 +79,7 @@ fun MainScreen(
         factory = viewModelFactory { MainScreenViewModel() },
     ),
 ) {
+    val privacyPolicy = remember { URL("https://usesmileid.com/privacy-policy") }
     val coroutineScope = rememberCoroutineScope()
     val navController = rememberNavController()
     val currentRoute by navController
@@ -213,7 +214,6 @@ fun MainScreen(
                         )
                     }
                     idInfo?.let {
-                        val url = remember { URL("https://usesmileid.com/privacy-policy") }
                         val userId = rememberSaveable { randomUserId() }
                         val jobId = rememberSaveable { randomJobId() }
                         SmileID.BiometricKYC(
@@ -225,7 +225,7 @@ fun MainScreen(
                             ),
                             partnerName = "Smile ID",
                             productName = it.idType!!,
-                            partnerPrivacyPolicy = url,
+                            partnerPrivacyPolicy = privacyPolicy,
                         ) { result ->
                             viewModel.onBiometricKycResult(userId, jobId, result)
                             navController.popBackStack()
@@ -266,13 +266,27 @@ fun MainScreen(
                 }
                 composable(ProductScreen.BvnConsent.route) {
                     LaunchedEffect(Unit) { viewModel.onBvnConsentSelected() }
-                    SmileID.BvnConsentScreen {
-                        viewModel.onSuccessfulBvnConsent()
-                        navController.popBackStack(
-                            route = BottomNavigationScreen.Home.route,
-                            inclusive = false,
-                        )
-                    }
+                    SmileID.BvnConsentScreen(
+                        partnerIcon = painterResource(
+                            id = com.smileidentity.R.drawable.si_logo_with_text,
+                        ),
+                        partnerName = stringResource(com.smileidentity.R.string.si_company_name),
+                        partnerPrivacyPolicy = privacyPolicy,
+                        onConsentDenied = {
+                            viewModel.onConsentDenied()
+                            navController.popBackStack(
+                                route = BottomNavigationScreen.Home.route,
+                                inclusive = false,
+                            )
+                        },
+                        onConsentGranted = {
+                            viewModel.onSuccessfulBvnConsent()
+                            navController.popBackStack(
+                                route = BottomNavigationScreen.Home.route,
+                                inclusive = false,
+                            )
+                        },
+                    )
                 }
             }
         },

--- a/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
@@ -442,8 +442,12 @@ private fun Snackbar(viewModel: MainScreenViewModel = viewModel()) {
     val snackbarMessage = viewModel.uiState.collectAsStateWithLifecycle().value.snackbarMessage
 
     LaunchedEffect(snackbarMessage) {
-        snackbarMessage?.let { coroutineScope.launch { snackbarHostState.showSnackbar(it) } }
-        viewModel.clearSnackbar()
+        snackbarMessage?.let {
+            coroutineScope.launch {
+                snackbarHostState.showSnackbar(it)
+                viewModel.clearSnackbar()
+            }
+        }
     }
 
     SnackbarHost(snackbarHostState) {

--- a/sample/src/main/java/com/smileidentity/sample/viewmodel/MainScreenViewModel.kt
+++ b/sample/src/main/java/com/smileidentity/sample/viewmodel/MainScreenViewModel.kt
@@ -442,6 +442,12 @@ class MainScreenViewModel : ViewModel() {
         }
     }
 
+    fun onConsentDenied() {
+        _uiState.update {
+            it.copy(snackbarMessage = SnackbarMessage("Consent Denied"))
+        }
+    }
+
     fun onSuccessfulBvnConsent() {
         _uiState.update {
             it.copy(snackbarMessage = SnackbarMessage("BVN Consent Successful"))

--- a/sample/src/main/java/com/smileidentity/sample/viewmodel/MainScreenViewModel.kt
+++ b/sample/src/main/java/com/smileidentity/sample/viewmodel/MainScreenViewModel.kt
@@ -41,17 +41,10 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-/**
- * Wrapper for the message, so that LaunchedEffect's key changes even if we need to display the same
- * message again. We *can't* use data class because the generated equals would be the same for the
- * same String
- */
-class SnackbarMessage(val value: String)
-
 data class MainScreenUiState(
     @StringRes val appBarTitle: Int = R.string.app_name,
     val isProduction: Boolean = !SmileID.useSandbox,
-    val snackbarMessage: SnackbarMessage? = null,
+    val snackbarMessage: String? = null,
     val bottomNavSelection: BottomNavigationScreen = startScreen,
     val pendingJobCount: Int = 0,
     val showSmileConfigBottomSheet: Boolean = false,
@@ -127,7 +120,7 @@ class MainScreenViewModel : ViewModel() {
                                 completedJob = it,
                             )
                             _uiState.update {
-                                it.copy(snackbarMessage = SnackbarMessage("Job Completed"))
+                                it.copy(snackbarMessage = "Job Completed")
                             }
                         } else {
                             DataStoreRepository.markPendingJobAsCompleted(
@@ -139,9 +132,7 @@ class MainScreenViewModel : ViewModel() {
                                 ),
                             )
                             _uiState.update {
-                                it.copy(
-                                    snackbarMessage = SnackbarMessage("Job Polling Timed Out"),
-                                )
+                                it.copy(snackbarMessage = "Job Polling Timed Out")
                             }
                         }
                     }
@@ -228,7 +219,7 @@ class MainScreenViewModel : ViewModel() {
             val response = result.data.jobStatusResponse ?: run {
                 val errorMessage = "SmartSelfie Enrollment jobStatusResponse is null"
                 Timber.e(errorMessage)
-                _uiState.update { it.copy(snackbarMessage = SnackbarMessage(errorMessage)) }
+                _uiState.update { it.copy(snackbarMessage = errorMessage) }
                 return
             }
             val actualResult = response.result as? SmartSelfieJobResult.Entry
@@ -245,7 +236,7 @@ class MainScreenViewModel : ViewModel() {
             _uiState.update {
                 it.copy(
                     clipboardText = AnnotatedString(userId),
-                    snackbarMessage = SnackbarMessage(message),
+                    snackbarMessage = message,
                 )
             }
             viewModelScope.launch {
@@ -259,7 +250,7 @@ class MainScreenViewModel : ViewModel() {
             val th = result.throwable
             val message = "SmartSelfie Enrollment error: ${th.message}"
             Timber.e(th, message)
-            _uiState.update { it.copy(snackbarMessage = SnackbarMessage(message)) }
+            _uiState.update { it.copy(snackbarMessage = message) }
         }
     }
 
@@ -281,7 +272,7 @@ class MainScreenViewModel : ViewModel() {
             val response = result.data.jobStatusResponse ?: run {
                 val errorMessage = "SmartSelfie Authentication jobStatusResponse is null"
                 Timber.e(errorMessage)
-                _uiState.update { it.copy(snackbarMessage = SnackbarMessage(errorMessage)) }
+                _uiState.update { it.copy(snackbarMessage = errorMessage) }
                 return
             }
             val actualResult = response.result as? SmartSelfieJobResult.Entry
@@ -294,7 +285,7 @@ class MainScreenViewModel : ViewModel() {
                 resultText = actualResult?.resultText,
             )
             Timber.d("$message: $result")
-            _uiState.update { it.copy(snackbarMessage = SnackbarMessage(message)) }
+            _uiState.update { it.copy(snackbarMessage = message) }
             viewModelScope.launch {
                 DataStoreRepository.addPendingJob(
                     partnerId = SmileID.config.partnerId,
@@ -306,7 +297,7 @@ class MainScreenViewModel : ViewModel() {
             val th = result.throwable
             val message = "SmartSelfie Authentication error: ${th.message}"
             Timber.e(th, message)
-            _uiState.update { it.copy(snackbarMessage = SnackbarMessage(message)) }
+            _uiState.update { it.copy(snackbarMessage = message) }
         }
     }
 
@@ -331,7 +322,7 @@ class MainScreenViewModel : ViewModel() {
                 resultText = resultData.resultText,
             )
             Timber.d("$message: $result")
-            _uiState.update { it.copy(snackbarMessage = SnackbarMessage(message)) }
+            _uiState.update { it.copy(snackbarMessage = message) }
             viewModelScope.launch {
                 // Enhanced KYC completes synchronously
                 DataStoreRepository.addCompletedJob(
@@ -344,7 +335,7 @@ class MainScreenViewModel : ViewModel() {
             val th = result.throwable
             val message = "Enhanced KYC error: ${th.message}"
             Timber.e(th, message)
-            _uiState.update { it.copy(snackbarMessage = SnackbarMessage(message)) }
+            _uiState.update { it.copy(snackbarMessage = message) }
         }
     }
 
@@ -375,7 +366,7 @@ class MainScreenViewModel : ViewModel() {
                 resultText = actualResult?.resultText,
             )
             Timber.d("$message: $result")
-            _uiState.update { it.copy(snackbarMessage = SnackbarMessage(message)) }
+            _uiState.update { it.copy(snackbarMessage = message) }
             viewModelScope.launch {
                 DataStoreRepository.addPendingJob(
                     partnerId = SmileID.config.partnerId,
@@ -387,7 +378,7 @@ class MainScreenViewModel : ViewModel() {
             val th = result.throwable
             val message = "Biometric KYC error: ${th.message}"
             Timber.e(th, message)
-            _uiState.update { it.copy(snackbarMessage = SnackbarMessage(message)) }
+            _uiState.update { it.copy(snackbarMessage = message) }
         }
     }
 
@@ -417,7 +408,7 @@ class MainScreenViewModel : ViewModel() {
                 resultText = actualResult?.resultText,
             )
             Timber.d("$message: $result")
-            _uiState.update { it.copy(snackbarMessage = SnackbarMessage(message)) }
+            _uiState.update { it.copy(snackbarMessage = message) }
             viewModelScope.launch {
                 DataStoreRepository.addPendingJob(
                     partnerId = SmileID.config.partnerId,
@@ -429,7 +420,7 @@ class MainScreenViewModel : ViewModel() {
             val th = result.throwable
             val message = "Document Verification error: ${th.message}"
             Timber.e(th, message)
-            _uiState.update { it.copy(snackbarMessage = SnackbarMessage(message)) }
+            _uiState.update { it.copy(snackbarMessage = message) }
         }
     }
 
@@ -444,13 +435,13 @@ class MainScreenViewModel : ViewModel() {
 
     fun onConsentDenied() {
         _uiState.update {
-            it.copy(snackbarMessage = SnackbarMessage("Consent Denied"))
+            it.copy(snackbarMessage = "Consent Denied")
         }
     }
 
     fun onSuccessfulBvnConsent() {
         _uiState.update {
-            it.copy(snackbarMessage = SnackbarMessage("BVN Consent Successful"))
+            it.copy(snackbarMessage = "BVN Consent Successful")
         }
     }
 
@@ -458,5 +449,9 @@ class MainScreenViewModel : ViewModel() {
         viewModelScope.launch {
             DataStoreRepository.clearJobs(SmileID.config.partnerId, !SmileID.useSandbox)
         }
+    }
+
+    fun clearSnackbar() {
+        _uiState.update { it.copy(snackbarMessage = null) }
     }
 }


### PR DESCRIPTION
## Summary

Show the consent screen prior to BVN verification
Moves the try again flow to be part of a new `OrchestratedConsentScreen` composable
