### PR TITLE
Pass showAttribution to ConsentDeniedScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+- Fix bug where `showAttirubtion` was not respected on the Consent Denied screen
 
 ### Changed
 

--- a/lib/src/main/java/com/smileidentity/compose/consent/OrchestratedConsentScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/OrchestratedConsentScreen.kt
@@ -29,6 +29,7 @@ internal fun OrchestratedConsentScreen(
             onGoBack = { showTryAgain = false },
             onCancel = onConsentDenied,
             modifier = modifier,
+            showAttribution = showAttribution,
         )
     } else {
         ConsentScreen(

--- a/lib/src/main/java/com/smileidentity/compose/consent/bvn/BvnInputScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/consent/bvn/BvnInputScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -36,7 +35,6 @@ import com.smileidentity.compose.preview.SmilePreviews
 import com.smileidentity.viewmodel.BvnConsentViewModel
 import com.smileidentity.viewmodel.viewModelFactory
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun BvnInputScreen(
     userId: String,

--- a/lib/src/main/java/com/smileidentity/models/Bvn.kt
+++ b/lib/src/main/java/com/smileidentity/models/Bvn.kt
@@ -34,7 +34,7 @@ data class BvnTotpResponse(
     @Json(name = "message")
     val message: String,
     @Json(name = "modes")
-    val modes: List<BvnVerificationMode> = emptyList(),
+    val modes: List<BvnVerificationMode>,
     @Json(name = "session_id")
     val sessionId: String,
     @Json(name = "signature")


### PR DESCRIPTION
Fix bug where `showAttirubtion` was not respected on the Consent Denied screen