### PR TITLE
Use clipPath instead of BlendMode.Clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 ### Fixed
-- Fixed retry document submission on failed document submission
+- Fixed a bug where the document preview showed a black box for some older devices
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 10.0.0-beta12 (unreleased)
+## 10.0.0-beta13 (unreleased)
+
+### Added
+
+### Fixed
+
+### Changed
+
+## 10.0.0-beta12
 
 ### Added
 

--- a/lib/VERSION
+++ b/lib/VERSION
@@ -1,1 +1,1 @@
-10.0.0-beta11-SNAPSHOT
+10.0.0-beta12-SNAPSHOT


### PR DESCRIPTION
## Summary

For the Document Bounding Box, we were drawing a box with `BlendMode.Clear` to create a cutout from the background scrim. This resulted in a bug on some older devices (Android 7, specifically) where the blending would not occur properly and a black box would be shown instead.

This approach switches to using `clipPath` instead to clip the background from being drawn at the location of the bounding box in the first place (using `ClipOp.Difference`). This is the same approach that the `FaceShapedProgressIndicator` takes