### PR TITLE
Fix `SmileIDException` Parcelable error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 ### Added
 
 ### Fixed
+- Fixed a bug when attempting to parcelize `SmileIDException`
 
 ### Changed
+
+### Removed
 
 ## 10.0.0-beta13
 
@@ -14,20 +17,10 @@
 - Added `extras` as optional params on all job types
 - Added `allowAgentMode` option on Document Verification and Enhanced Document Verification
 
-### Fixed
-
-### Changed
-
 ## 10.0.0-beta12
-
-### Added
 
 ### Fixed
 - Fixed a bug where the document preview showed a black box for some older devices
-
-### Changed
-
-### Removed
 
 ## 10.0.0-beta11
 

--- a/lib/src/main/java/com/smileidentity/models/Models.kt
+++ b/lib/src/main/java/com/smileidentity/models/Models.kt
@@ -8,19 +8,26 @@ import com.smileidentity.util.randomUserId
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
+import java.io.Serializable
 
 @Suppress("CanBeParameter", "MemberVisibilityCanBePrivate")
 @Parcelize
 class SmileIDException(val details: Details) : Exception(details.message), Parcelable {
 
-    // This Exception+Details is defined in this way to satisfy Moshi (it doesn't like data classes
-    // to have parent classes - i.e. Exception as a parent class)
+    /**
+     * This Exception+Details is defined in this way to satisfy Moshi (it doesn't like data classes
+     * to have parent classes - i.e. Exception as a parent class)
+     *
+     * This class implements [Serializable] in order to allow [SmileIDException] to be [Parcelable].
+     * This is because the parent class is [Exception], which is Serializable but not Parcelable,
+     * and therefore, all members of [SmileIDException] must also be [Serializable]
+     */
     @Parcelize
     @JsonClass(generateAdapter = true)
     data class Details(
         @Json(name = "code") val code: String,
         @Json(name = "error") val message: String,
-    ) : Parcelable
+    ) : Parcelable, Serializable
 }
 
 /**


### PR DESCRIPTION
Fixes https://smile-identity.sentry.io/issues/4632927488

## Summary

`SmileIDException` extends `Exception`, which is `Serializable`. Therefore, when attempting to write to a `Parcel`, it is written as a `Serialable` which requires that all members also implement `Serializable`