### PR TITLE
Change Sentry log level of coroutine exception handler

### DIFF
--- a/lib/src/main/java/com/smileidentity/util/Util.kt
+++ b/lib/src/main/java/com/smileidentity/util/Util.kt
@@ -31,6 +31,8 @@ import com.smileidentity.SmileIDCrashReporting
 import com.smileidentity.compose.consent.bvn.BvnOtpVerificationMode
 import com.smileidentity.models.BvnVerificationMode
 import com.smileidentity.models.SmileIDException
+import io.sentry.Breadcrumb
+import io.sentry.SentryLevel
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineExceptionHandler
 import retrofit2.HttpException
@@ -258,7 +260,10 @@ fun getExceptionHandler(proxy: (Throwable) -> Unit) = CoroutineExceptionHandler 
         }
     } else {
         // Unexpected error, report to Sentry
-        SmileIDCrashReporting.hub.captureException(throwable)
+        SmileIDCrashReporting.hub.captureException(throwable) {
+            it.level = SentryLevel.INFO
+            it.addBreadcrumb(Breadcrumb("Smile ID Coroutine Exception Handler"))
+        }
         throwable
     }
     proxy(converted)


### PR DESCRIPTION
## Summary

Reduces the log level of exceptions captured in our exception handler. This is because these are non-fatal errors (i.e. networking issues) and such errors are gracefully handled already. We still want to capture them, however, for insights into the type of issues that crop up