### PR TITLE
Made `code` nullable on `SmileIDException.Details`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+- Made `code` nullable on `SmileIDException.Details`
 
 ### Changed
 

--- a/lib/src/main/java/com/smileidentity/models/Models.kt
+++ b/lib/src/main/java/com/smileidentity/models/Models.kt
@@ -25,7 +25,7 @@ class SmileIDException(val details: Details) : Exception(details.message), Parce
     @Parcelize
     @JsonClass(generateAdapter = true)
     data class Details(
-        @Json(name = "code") val code: String,
+        @Json(name = "code") val code: String?,
         @Json(name = "error") val message: String,
     ) : Parcelable, Serializable
 }


### PR DESCRIPTION
## Summary

`code` may not be returned if an error is thrown by API Gateway

Resolves https://smile-identity.sentry.io/issues/4688954866