### PR TITLE
Upstream unrelated changes from the tf branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Bump CameraX to 1.3.0
+- Removed `cameraConfig` from `PrepUploadResponse`
 
 ## 10.0.3
 ### Added

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-accompanist-permissions = "0.34.0"
+accompanist-permissions = "0.32.0"
 android-gradle-plugin = "8.2.2"
 androidx-activity = "1.8.2"
 # TODO: Check if https://android-review.googlesource.com/c/platform/frameworks/support/+/2576871 has
 #  been merged and if so, swap the buttons in ImageCaptureConfirmationDialog
-androidx-compose-bom = "2024.01.00"
+androidx-compose-bom = "2023.10.01"
 androidx-compose-compiler = "1.5.8"
 androidx-core = "1.12.0"
 androidx-core-splashscreen = "1.0.1"

--- a/lib/src/main/java/com/smileidentity/models/PrepUpload.kt
+++ b/lib/src/main/java/com/smileidentity/models/PrepUpload.kt
@@ -28,5 +28,4 @@ data class PrepUploadResponse(
     @Json(name = "ref_id") val refId: String,
     @Json(name = "upload_url") val uploadUrl: String,
     @Json(name = "smile_job_id") val smileJobId: String,
-    @Json(name = "camera_config") val cameraConfig: String?,
 )

--- a/lib/src/main/java/com/smileidentity/util/Util.kt
+++ b/lib/src/main/java/com/smileidentity/util/Util.kt
@@ -101,6 +101,28 @@ internal fun isValidDocumentImage(
     uri: Uri?,
 ) = isImageAtLeast(context, uri, width = 1920, height = 1080)
 
+fun Bitmap.rotated(
+    rotationDegrees: Int,
+    flipX: Boolean = false,
+    flipY: Boolean = false,
+): Bitmap {
+    val matrix = Matrix()
+
+    // Rotate the image back to straight.
+    matrix.postRotate(rotationDegrees.toFloat())
+
+    // Mirror the image along the X or Y axis.
+    matrix.postScale(if (flipX) -1.0f else 1.0f, if (flipY) -1.0f else 1.0f)
+    val rotatedBitmap =
+        Bitmap.createBitmap(this, 0, 0, width, height, matrix, true)
+
+    // Recycle the old bitmap if it has changed.
+    if (rotatedBitmap !== this) {
+        recycle()
+    }
+    return rotatedBitmap
+}
+
 /**
  * Post-processes the image stored in [bitmap] and saves to [file]. The image is scaled to
  * [maxOutputSize], but maintains the aspect ratio. The image can also converted to grayscale.

--- a/lib/src/main/java/com/smileidentity/viewmodel/SelfieViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/SelfieViewModel.kt
@@ -1,7 +1,5 @@
 package com.smileidentity.viewmodel
 
-import android.graphics.Bitmap
-import android.graphics.Matrix
 import android.util.Size
 import androidx.annotation.OptIn
 import androidx.annotation.StringRes
@@ -33,6 +31,7 @@ import com.smileidentity.util.createLivenessFile
 import com.smileidentity.util.createSelfieFile
 import com.smileidentity.util.getExceptionHandler
 import com.smileidentity.util.postProcessImageBitmap
+import com.smileidentity.util.rotated
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.FlowPreview
@@ -343,27 +342,5 @@ class SelfieViewModel(
 
     fun onFinished(callback: SmileIDCallback<SmartSelfieResult>) {
         callback(result!!)
-    }
-
-    private fun Bitmap.rotated(
-        rotationDegrees: Int,
-        flipX: Boolean = false,
-        flipY: Boolean = false,
-    ): Bitmap {
-        val matrix = Matrix()
-
-        // Rotate the image back to straight.
-        matrix.postRotate(rotationDegrees.toFloat())
-
-        // Mirror the image along the X or Y axis.
-        matrix.postScale(if (flipX) -1.0f else 1.0f, if (flipY) -1.0f else 1.0f)
-        val rotatedBitmap =
-            Bitmap.createBitmap(this, 0, 0, width, height, matrix, true)
-
-        // Recycle the old bitmap if it has changed.
-        if (rotatedBitmap !== this) {
-            recycle()
-        }
-        return rotatedBitmap
     }
 }

--- a/lib/src/test/java/com/smileidentity/viewmodel/document/DocumentViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/document/DocumentViewModelTest.kt
@@ -128,7 +128,6 @@ class DocumentViewModelTest {
             refId = "refId",
             uploadUrl = "uploadUrl",
             smileJobId = "smileJobId",
-            cameraConfig = null,
         )
 
         coEvery { SmileID.api.getDocumentVerificationJobStatus(any()) } returns
@@ -174,7 +173,6 @@ class DocumentViewModelTest {
             refId = "refId",
             uploadUrl = "uploadUrl",
             smileJobId = "smileJobId",
-            cameraConfig = null,
         )
 
         coEvery { SmileID.api.getDocumentVerificationJobStatus(any()) } returns

--- a/lib/src/test/java/com/smileidentity/viewmodel/document/EnhancedDocumentVerificationViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/document/EnhancedDocumentVerificationViewModelTest.kt
@@ -128,7 +128,6 @@ class EnhancedDocumentVerificationViewModelTest {
             refId = "refId",
             uploadUrl = "uploadUrl",
             smileJobId = "smileJobId",
-            cameraConfig = null,
         )
 
         coEvery { SmileID.api.getEnhancedDocumentVerificationJobStatus(any()) } returns
@@ -174,7 +173,6 @@ class EnhancedDocumentVerificationViewModelTest {
             refId = "refId",
             uploadUrl = "uploadUrl",
             smileJobId = "smileJobId",
-            cameraConfig = null,
         )
 
         coEvery { SmileID.api.getEnhancedDocumentVerificationJobStatus(any()) } returns

--- a/sample/src/main/java/com/smileidentity/sample/Screen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/Screen.kt
@@ -2,16 +2,15 @@ package com.smileidentity.sample
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.Icons.Outlined
-import androidx.compose.material.icons.automirrored.filled.List
-import androidx.compose.material.icons.automirrored.outlined.List
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.List
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
 
@@ -77,8 +76,8 @@ enum class BottomNavigationScreen(
     Jobs(
         "jobs",
         R.string.jobs,
-        Icons.AutoMirrored.Filled.List,
-        Icons.AutoMirrored.Outlined.List,
+        Filled.List,
+        Outlined.List,
     ),
     Resources(
         "resources",

--- a/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
@@ -1,11 +1,12 @@
 package com.smileidentity.sample.compose
 
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
@@ -74,6 +75,7 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import java.net.URL
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun MainScreen(
     modifier: Modifier = Modifier,
@@ -360,7 +362,7 @@ private fun TopBar(
             if (showUpButton) {
                 IconButton(onClick = onNavigateUp) {
                     Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        imageVector = Icons.Filled.ArrowBack,
                         contentDescription = stringResource(R.string.back),
                     )
                 }

--- a/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
@@ -1,6 +1,5 @@
 package com.smileidentity.sample.compose
 
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -47,6 +46,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.dialog
 import androidx.navigation.compose.rememberNavController
 import com.smileidentity.SmileID
 import com.smileidentity.compose.BiometricKYC
@@ -73,7 +74,6 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import java.net.URL
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun MainScreen(
     modifier: Modifier = Modifier,
@@ -81,23 +81,16 @@ fun MainScreen(
         factory = viewModelFactory { MainScreenViewModel() },
     ),
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val privacyPolicy = remember { URL("https://usesmileid.com/privacy-policy") }
     val coroutineScope = rememberCoroutineScope()
     val navController = rememberNavController()
-    val currentRoute by navController
-        .currentBackStackEntryFlow
-        .collectAsStateWithLifecycle(initialValue = navController.currentBackStackEntry)
-
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val currentRoute by navController.currentBackStackEntryAsState()
     val bottomNavSelection = uiState.bottomNavSelection
-
     val bottomNavItems = remember { BottomNavigationScreen.entries.toImmutableList() }
-    // Show up button when not on a BottomNavigationScreen
-    val showUpButton = currentRoute?.destination?.route?.let { route ->
-        bottomNavItems.none { it.route.contains(route) }
-    } ?: false
-
+    val dialogDestinations = remember { listOf(ProductScreen.SmartSelfieAuthentication.route) }
     val clipboardManager = LocalClipboardManager.current
+
     LaunchedEffect(uiState.clipboardText) {
         uiState.clipboardText?.let { text ->
             coroutineScope.launch {
@@ -109,6 +102,10 @@ fun MainScreen(
         modifier = modifier,
         snackbarHost = { Snackbar() },
         topBar = {
+            // Show up button when not on a BottomNavigationScreen
+            val showUpButton = currentRoute?.destination?.route?.let { route ->
+                bottomNavItems.none { it.route.contains(route) }
+            } ?: false
             TopBar(
                 showUpButton = showUpButton,
                 onNavigateUp = navController::navigateUp,
@@ -119,7 +116,13 @@ fun MainScreen(
             // Don't show bottom bar when navigating to any product screens
             val showBottomBar by remember(currentRoute) {
                 derivedStateOf {
-                    bottomNavItems.any { it.route.contains(currentRoute?.destination?.route ?: "") }
+                    val isDirectlyOnBottomNavDestination = bottomNavItems.any {
+                        it.route.contains(currentRoute?.destination?.route ?: "")
+                    }
+                    val isOnDialogDestination = dialogDestinations.any {
+                        it.contains(currentRoute?.destination?.route ?: "")
+                    }
+                    return@derivedStateOf isDirectlyOnBottomNavDestination || isOnDialogDestination
                 }
             }
             if (showBottomBar) {
@@ -175,10 +178,13 @@ fun MainScreen(
                         navController.popBackStack()
                     }
                 }
-                composable(ProductScreen.SmartSelfieAuthentication.route) {
+                dialog(ProductScreen.SmartSelfieAuthentication.route) {
                     LaunchedEffect(Unit) { viewModel.onSmartSelfieAuthenticationSelected() }
                     SmartSelfieAuthenticationUserIdInputDialog(
-                        onDismiss = navController::popBackStack,
+                        onDismiss = {
+                            viewModel.onHomeSelected()
+                            navController.popBackStack()
+                        },
                         onConfirm = { userId ->
                             navController.navigate(
                                 "${ProductScreen.SmartSelfieAuthentication.route}/$userId",

--- a/sample/src/main/java/com/smileidentity/sample/compose/ProductScreens.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/ProductScreens.kt
@@ -2,6 +2,7 @@ package com.smileidentity.sample.compose
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -22,14 +23,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.smileidentity.SmileID
 import com.smileidentity.sample.BuildConfig
@@ -37,15 +37,8 @@ import com.smileidentity.sample.ProductScreen
 import com.smileidentity.sample.R
 import com.smileidentity.sample.Screen
 
-val products = listOf(
-    ProductScreen.SmartSelfieEnrollment,
-    ProductScreen.SmartSelfieAuthentication,
-    ProductScreen.EnhancedKyc,
-    ProductScreen.BiometricKyc,
-    ProductScreen.BvnConsent,
-    ProductScreen.DocumentVerification,
-    ProductScreen.EnhancedDocumentVerification,
-)
+private val products = ProductScreen.entries
+private val roundedCornerShape = RoundedCornerShape(16.dp)
 
 @Composable
 fun ProductSelectionScreen(
@@ -58,17 +51,30 @@ fun ProductSelectionScreen(
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
-                .padding(16.dp)
+                .padding(start = 16.dp, end = 16.dp, bottom = 2.dp)
                 .weight(1f),
         ) {
             Text(
                 stringResource(R.string.test_our_products),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(vertical = 8.dp),
             )
-            ProductsGrid(onProductSelected)
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                verticalArrangement = spacedBy(8.dp),
+                horizontalArrangement = spacedBy(8.dp),
+                modifier = Modifier.clip(roundedCornerShape),
+            ) {
+                items(products) {
+                    ProductCell(
+                        productScreen = it,
+                        onProductSelected = onProductSelected,
+                        modifier = Modifier.defaultMinSize(minHeight = 164.dp),
+                    )
+                }
+            }
         }
         SelectionContainer {
             Text(
@@ -79,64 +85,26 @@ fun ProductSelectionScreen(
                 ),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.typography.labelMedium.color.copy(alpha = .5f),
-                modifier = Modifier.padding(12.dp),
+                modifier = Modifier.padding(bottom = 2.dp),
             )
         }
     }
 }
 
-/**
- * We'd like each product cell to be the same height. However, we don't know the height of the
- * tallest cell until we've measured them all. So we need to measure them all twice. Once to find
- * the tallest cell, and again to actually lay them out.
- *
- * We do this by using a [SubcomposeLayout] with 2 subcompositions. The first one measures each cell
- * and returns the tallest height. The second subcomposition creates the actual grid layout.
- */
-@Composable
-private fun ProductsGrid(onProductSelected: (Screen) -> Unit) {
-    SubcomposeLayout { constraints ->
-        // The true/false passed to subcompose is merely because we need 2 unique keys
-        val maxHeight = subcompose(true) {
-            products.map { ProductCell(it, onProductSelected, 0.dp) }
-        }.maxOf { it.measure(constraints).measuredHeight.toDp() }
-
-        val contentPlaceable = subcompose(false) {
-            LazyVerticalGrid(columns = GridCells.Fixed(2)) {
-                items(products) {
-                    ProductCell(it, onProductSelected, maxHeight)
-                }
-            }
-        }.first().measure(constraints)
-
-        layout(contentPlaceable.measuredWidth, maxHeight.roundToPx()) {
-            contentPlaceable.place(0, 0)
-        }
-    }
-}
-
-/**
- * [minHeight] is used so that 0.dp can be passed to the [ProductCell] composable as part of an
- * initial pass to measure the final max height. Once a max height is determined, the minHeight
- * is guaranteed to be greater than 0.dp
- */
 @Composable
 private fun ProductCell(
     productScreen: ProductScreen,
     onProductSelected: (Screen) -> Unit,
-    minHeight: Dp,
+    modifier: Modifier = Modifier,
 ) {
     FilledTonalButton(
         onClick = { onProductSelected(productScreen) },
-        shape = RoundedCornerShape(16.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(4.dp),
+        shape = roundedCornerShape,
+        modifier = modifier.fillMaxWidth(),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.SpaceAround,
-            modifier = Modifier.defaultMinSize(minHeight = minHeight),
         ) {
             Image(
                 painterResource(productScreen.icon),

--- a/sample/src/main/java/com/smileidentity/sample/compose/ResourcesScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/ResourcesScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Star
@@ -73,7 +73,7 @@ fun ResourcesScreen(
             ListItem(
                 headlineContent = { Text(it.first) },
                 supportingContent = { Text(it.second) },
-                trailingContent = { Icon(Icons.AutoMirrored.Filled.ArrowForward, null) },
+                trailingContent = { Icon(Icons.Filled.ArrowForward, null) },
                 modifier = Modifier.clickable(onClick = it.third),
             )
             Divider()
@@ -82,7 +82,7 @@ fun ResourcesScreen(
             ListItem(
                 headlineContent = { Text(stringResource(it.first)) },
                 leadingContent = { Icon(it.second, null) },
-                trailingContent = { Icon(Icons.AutoMirrored.Filled.ArrowForward, null) },
+                trailingContent = { Icon(Icons.Filled.ArrowForward, null) },
                 modifier = Modifier.clickable(onClick = it.third),
             )
             Divider()

--- a/sample/src/main/java/com/smileidentity/sample/compose/SettingsScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/SettingsScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
@@ -68,7 +68,7 @@ fun SettingsScreen(
                 ListItem(
                     headlineContent = { Text(stringResource(it.first)) },
                     leadingContent = { Icon(it.second, null) },
-                    trailingContent = { Icon(Icons.AutoMirrored.Filled.ArrowForward, null) },
+                    trailingContent = { Icon(Icons.Filled.ArrowForward, null) },
                     modifier = Modifier.clickable(onClick = it.third),
                 )
                 Divider()

--- a/sample/src/main/java/com/smileidentity/sample/compose/jobs/JobsListScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/jobs/JobsListScreen.kt
@@ -154,11 +154,11 @@ private fun JobListItem(
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     val halfCircleRotationDegrees = 180f
-                    val animatedProgress = animateFloatAsState(
+                    val animatedProgress by animateFloatAsState(
                         targetValue = if (expanded) halfCircleRotationDegrees else 0f,
                         animationSpec = spring(),
                         label = "Dropdown Icon Rotation",
-                    ).value
+                    )
                     Icon(
                         imageVector = Icons.Filled.KeyboardArrowDown,
                         contentDescription = null,


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/11537

## Summary

- Downgrade Compose BOM back to `10.01.00` and Accompanist to fix a crash
- Improve ProductGrid scrolling
- Improve Home Screen layout time
- Dialog lays on top of content rather than its own screen
- Remove cameraConfig from PrepUploadResponse
- Move Bitmap.rotated extension function to Util
- Use new AndroidX method for screen state Flowable