### PR TITLE
Add allowUserToSkipBackCapture parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added a new parameter, `allowUserToSkipBackCapture`, to DocumentVerification and
+  EnhancedDocumentVerification to enforce the user to capture the back of the document. The default 
+  value is `true` (to maintain backward compatibility, since previously the user could always skip).
+  This parameter is only relevant when `captureBothSides` is `true`.
 - Bump CameraX to 1.3.0
 - Removed `cameraConfig` from `PrepUploadResponse`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## Unreleased
 - Added a new parameter, `allowUserToSkipBackCapture`, to DocumentVerification and
   EnhancedDocumentVerification to enforce the user to capture the back of the document. The default 
-  value is `true` (to maintain backward compatibility, since previously the user could always skip).
-  This parameter is only relevant when `captureBothSides` is `true`.
+  value is `true`. This parameter is only relevant when `captureBothSides` is also `true`
 - Bump CameraX to 1.3.0
 - Removed `cameraConfig` from `PrepUploadResponse`
 

--- a/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
+++ b/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
@@ -149,11 +149,12 @@ fun SmileID.SmartSelfieAuthentication(
  *
  * @param countryCode The ISO 3166-1 alpha-3 country code of the document
  * @param documentType An optional document type of the document
- * @param captureBothSides Determines if the document has a back side
- * @param idAspectRatio The aspect ratio of the ID to be captured. If not specified, the aspect
- * ratio will attempt to be inferred from the device's camera.
  * @param captureBothSides Whether to capture both sides of the ID or not. Otherwise, only the front
  * side will be captured.
+ * @param allowUserToSkipBackCapture Whether to allow the user to skip capturing the back side of
+ * the ID. NB! This is only applicable if [captureBothSides] is true.
+ * @param idAspectRatio The aspect ratio of the ID to be captured. If not specified, the aspect
+ * ratio will attempt to be inferred from the device's camera.
  * @param bypassSelfieCaptureWithFile If provided, the user will not be prompted to take a selfie
  * and instead the provided file will be used as the selfie image
  * @param userId The user ID to associate with the Document Verification. Most often, this will
@@ -182,6 +183,7 @@ fun SmileID.DocumentVerification(
     modifier: Modifier = Modifier,
     documentType: String? = null,
     captureBothSides: Boolean = true,
+    allowUserToSkipBackCapture: Boolean = true,
     idAspectRatio: Float? = null,
     bypassSelfieCaptureWithFile: File? = null,
     userId: String = rememberSaveable { randomUserId() },
@@ -200,6 +202,7 @@ fun SmileID.DocumentVerification(
         OrchestratedDocumentVerificationScreen(
             modifier = modifier,
             captureBothSides = captureBothSides,
+            allowUserToSkipBackCapture = allowUserToSkipBackCapture,
             userId = userId,
             jobId = jobId,
             showAttribution = showAttribution,
@@ -234,9 +237,10 @@ fun SmileID.DocumentVerification(
  *
  * @param countryCode The ISO 3166-1 alpha-3 country code of the document
  * @param documentType An optional document type of the document
- * @param captureBothSides Determines if the document has a back side
  * @param captureBothSides Whether to capture both sides of the ID or not. Otherwise, only the front
  * side will be captured.
+ * @param allowUserToSkipBackCapture Whether to allow the user to skip capturing the back side of
+ * the ID. NB! This is only applicable if [captureBothSides] is true.
  * @param idAspectRatio The aspect ratio of the ID to be captured. If not specified, the aspect
  * ratio will attempt to be inferred from the device's camera. If that fails, it will default to a
  * standard size of ~1.6
@@ -266,6 +270,7 @@ fun SmileID.EnhancedDocumentVerificationScreen(
     modifier: Modifier = Modifier,
     documentType: String? = null,
     captureBothSides: Boolean = true,
+    allowUserToSkipBackCapture: Boolean = true,
     idAspectRatio: Float? = null,
     userId: String = rememberSaveable { randomUserId() },
     jobId: String = rememberSaveable { randomJobId() },
@@ -283,6 +288,7 @@ fun SmileID.EnhancedDocumentVerificationScreen(
         OrchestratedDocumentVerificationScreen(
             modifier = modifier,
             captureBothSides = captureBothSides,
+            allowUserToSkipBackCapture = allowUserToSkipBackCapture,
             userId = userId,
             jobId = jobId,
             showAttribution = showAttribution,

--- a/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
@@ -33,6 +33,7 @@ internal fun <T : Parcelable> OrchestratedDocumentVerificationScreen(
     viewModel: OrchestratedDocumentViewModel<T>,
     modifier: Modifier = Modifier,
     captureBothSides: Boolean = true,
+    allowUserToSkipBackCapture: Boolean = true,
     idAspectRatio: Float? = null,
     userId: String = rememberSaveable { randomUserId() },
     jobId: String = rememberSaveable { randomJobId() },
@@ -73,7 +74,7 @@ internal fun <T : Parcelable> OrchestratedDocumentVerificationScreen(
                 showInstructions = showInstructions,
                 showAttribution = showAttribution,
                 allowGallerySelection = allowGalleryUpload,
-                showSkipButton = captureBothSides,
+                showSkipButton = allowUserToSkipBackCapture,
                 instructionsTitleText = stringResource(R.string.si_doc_v_instruction_back_title),
                 instructionsSubtitleText = stringResource(
                     id = R.string.si_doc_v_instruction_back_subtitle,

--- a/lib/src/main/java/com/smileidentity/fragment/DocumentVerificationFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/DocumentVerificationFragment.kt
@@ -78,6 +78,7 @@ class DocumentVerificationFragment : Fragment() {
             showInstructions: Boolean = true,
             idAspectRatio: Float? = null,
             captureBothSides: Boolean = false,
+            allowUserToSkipBackCapture: Boolean = true,
             bypassSelfieCaptureWithFile: File? = null,
             extraPartnerParams: HashMap<String, String>? = null,
         ) = DocumentVerificationFragment().apply {
@@ -93,6 +94,7 @@ class DocumentVerificationFragment : Fragment() {
                 this.documentType = documentType
                 this.idAspectRatio = idAspectRatio ?: -1f
                 this.captureBothSides = captureBothSides
+                this.allowUserToSkipBackCapture = allowUserToSkipBackCapture
                 this.bypassSelfieCaptureWithFile = bypassSelfieCaptureWithFile
                 this.extraPartnerParams = extraPartnerParams
             }
@@ -116,6 +118,8 @@ class DocumentVerificationFragment : Fragment() {
             SmileID.DocumentVerification(
                 countryCode = args.countryCode,
                 documentType = args.documentType,
+                captureBothSides = args.captureBothSides,
+                allowUserToSkipBackCapture = args.allowUserToSkipBackCapture,
                 userId = args.userId,
                 jobId = args.jobId,
                 allowNewEnroll = args.allowNewEnroll,
@@ -191,6 +195,11 @@ private const val KEY_CAPTURE_BOTH_SIDES = "captureBothSides"
 private var Bundle.captureBothSides: Boolean
     get() = getBoolean(KEY_CAPTURE_BOTH_SIDES)
     set(value) = putBoolean(KEY_CAPTURE_BOTH_SIDES, value)
+
+private const val KEY_ALLOW_USER_TO_SKIP_BACK_CAPTURE = "allowUserToSkipBackCapture"
+private var Bundle.allowUserToSkipBackCapture: Boolean
+    get() = getBoolean(KEY_ALLOW_USER_TO_SKIP_BACK_CAPTURE)
+    set(value) = putBoolean(KEY_ALLOW_USER_TO_SKIP_BACK_CAPTURE, value)
 
 private const val KEY_BYPASS_SELFIE_CAPTURE_WITH_FILE = "bypassSelfieCaptureWithFile"
 private var Bundle.bypassSelfieCaptureWithFile: File?

--- a/lib/src/main/java/com/smileidentity/fragment/EnhancedDocumentVerificationFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/EnhancedDocumentVerificationFragment.kt
@@ -77,6 +77,7 @@ class EnhancedDocumentVerificationFragment : Fragment() {
             showInstructions: Boolean = true,
             idAspectRatio: Float? = null,
             captureBothSides: Boolean = false,
+            allowUserToSkipBackCapture: Boolean = true,
             extraPartnerParams: HashMap<String, String>? = null,
         ) = EnhancedDocumentVerificationFragment().apply {
             arguments = Bundle().apply {
@@ -91,6 +92,7 @@ class EnhancedDocumentVerificationFragment : Fragment() {
                 this.documentType = documentType
                 this.idAspectRatio = idAspectRatio ?: -1f
                 this.captureBothSides = captureBothSides
+                this.allowUserToSkipBackCapture = allowUserToSkipBackCapture
                 this.extraPartnerParams = extraPartnerParams
             }
         }
@@ -113,6 +115,8 @@ class EnhancedDocumentVerificationFragment : Fragment() {
             SmileID.EnhancedDocumentVerificationScreen(
                 countryCode = args.countryCode,
                 documentType = args.documentType,
+                captureBothSides = args.captureBothSides,
+                allowUserToSkipBackCapture = args.allowUserToSkipBackCapture,
                 userId = args.userId,
                 jobId = args.jobId,
                 allowNewEnroll = args.allowNewEnroll,
@@ -187,6 +191,11 @@ private const val KEY_CAPTURE_BOTH_SIDES = "captureBothSides"
 private var Bundle.captureBothSides: Boolean
     get() = getBoolean(KEY_CAPTURE_BOTH_SIDES)
     set(value) = putBoolean(KEY_CAPTURE_BOTH_SIDES, value)
+
+private const val KEY_ALLOW_USER_TO_SKIP_BACK_CAPTURE = "allowUserToSkipBackCapture"
+private var Bundle.allowUserToSkipBackCapture: Boolean
+    get() = getBoolean(KEY_ALLOW_USER_TO_SKIP_BACK_CAPTURE)
+    set(value) = putBoolean(KEY_ALLOW_USER_TO_SKIP_BACK_CAPTURE, value)
 
 private const val KEY_EXTRA_PARTNER_PARAMS = "extraPartnerParams"
 private var Bundle.extraPartnerParams: HashMap<String, String>?


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/11625

## Summary

Adds a new `allowUserToSkipBackCapture` boolean parameter to allow partners to enforce capturing the back of ID. This parameter is only relevant when `captureBothSides` is set to `true`

(see also: https://github.com/smileidentity/ios/pull/131)

## Test Instructions

Update MainScreen to pass `captureBothSides` to `true` and `allowUserToSkipBackCapture` to `false` for `DocumentVerification` and `EnhancedDocumentVerification`. Notice that the skip button doesn't show