### PR TITLE
Default Sample App to Production

### DIFF
--- a/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -372,16 +371,6 @@ private fun TopBar(
             FilterChip(
                 selected = uiState.isProduction,
                 onClick = viewModel::toggleEnvironment,
-                leadingIcon = {
-                    if (uiState.isProduction) {
-                        Icon(
-                            imageVector = Icons.Filled.Warning,
-                            contentDescription = stringResource(
-                                R.string.production,
-                            ),
-                        )
-                    }
-                },
                 label = { Text(stringResource(id = uiState.environmentName)) },
             )
             if (isJobsScreenSelected) {

--- a/sample/src/main/java/com/smileidentity/sample/compose/RootScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/RootScreen.kt
@@ -56,7 +56,7 @@ fun RootScreen(
                     SmileID.initialize(
                         context = context,
                         config = runtimeConfig!!,
-                        useSandbox = true,
+                        useSandbox = false,
                         enableCrashReporting = !BuildConfig.DEBUG,
                         okHttpClient = client,
                     )
@@ -68,7 +68,7 @@ fun RootScreen(
                     initialized = false
                     SmileID.initialize(
                         context = context,
-                        useSandbox = true,
+                        useSandbox = false,
                         enableCrashReporting = !BuildConfig.DEBUG,
                         okHttpClient = client,
                     )


### PR DESCRIPTION
## Summary

Defaults the Sample app to Production instead of Sandbox. Also removes the warning icon that used to be next to Production

## Test Instructions

Ensure the app starts in Production. Run a job and ensure it shows up in the correct environment