### PR TITLE
Disable Skip Button on Back ID Capture Screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Bump CameraX to 1.3.0
 - Removed `cameraConfig` from `PrepUploadResponse`
 - Fixed a bug where, in some cases, logs may not be printed
+- Removed the Skip Button from Back of ID Capture
 
 ## 10.0.3
 ### Added

--- a/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/OrchestratedDocumentVerificationScreen.kt
@@ -73,7 +73,7 @@ internal fun <T : Parcelable> OrchestratedDocumentVerificationScreen(
                 showInstructions = showInstructions,
                 showAttribution = showAttribution,
                 allowGallerySelection = allowGalleryUpload,
-                showSkipButton = captureBothSides,
+                showSkipButton = false,
                 instructionsTitleText = stringResource(R.string.si_doc_v_instruction_back_title),
                 instructionsSubtitleText = stringResource(
                     id = R.string.si_doc_v_instruction_back_subtitle,


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/11625

## Summary

When capturing the back of ID, don't show the skip button
