### PR TITLE
Allow release creation to trigger post release workflow

### DIFF
--- a/.github/workflows/release_sdk.yaml
+++ b/.github/workflows/release_sdk.yaml
@@ -95,7 +95,9 @@ jobs:
         uses: actions/create-release@v1
         id: create_release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT instead of GITHUB_TOKEN so that the post-release workflow triggers
+          # https://stackoverflow.com/a/69063453
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         with:
           release_name: v${{ steps.read_version.outputs.version }}
           tag_name: v${{ steps.read_version.outputs.version }}


### PR DESCRIPTION
Since releases are created by a Workflow, GitHub had a rule where it would not trigger any other workflows. Therefore our new post-release workflow didn't trigger. This updates our release creation to use the PAT that is already part of the repo instead of the workflow github token