### PR TITLE
Make `KEY_RESULT` internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Bump Compose BOM to 2024.02.00
+* Made `KEY_RESULT` constants in `Fragment`s `internal` to remove a footgun where the constant was easily confused with `KEY_REQUEST`
 
 ## 10.0.4
 

--- a/lib/src/main/java/com/smileidentity/fragment/BiometricKYCFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/BiometricKYCFragment.kt
@@ -13,6 +13,10 @@ import com.smileidentity.fragment.BiometricKYCFragment.Companion.KEY_REQUEST
 import com.smileidentity.fragment.BiometricKYCFragment.Companion.KEY_RESULT
 import com.smileidentity.fragment.BiometricKYCFragment.Companion.newInstance
 import com.smileidentity.fragment.BiometricKYCFragment.Companion.resultFromBundle
+import com.smileidentity.fragment.EnhancedDocumentVerificationFragment.Companion.KEY_REQUEST
+import com.smileidentity.fragment.EnhancedDocumentVerificationFragment.Companion.resultFromBundle
+import com.smileidentity.fragment.SmartSelfieEnrollmentFragment.Companion.KEY_REQUEST
+import com.smileidentity.fragment.SmartSelfieEnrollmentFragment.Companion.resultFromBundle
 import com.smileidentity.models.IdInfo
 import com.smileidentity.results.BiometricKycResult
 import com.smileidentity.results.SmileIDResult
@@ -65,7 +69,12 @@ import kotlinx.collections.immutable.toImmutableMap
 class BiometricKYCFragment : Fragment() {
     companion object {
         const val KEY_REQUEST = "BiometricKYCRequest"
-        const val KEY_RESULT = "BiometricKYCResult"
+
+        /**
+         * This is internal to prevent partners from accidentally using the wrong key. They only
+         * need [KEY_REQUEST]. Partners should use [resultFromBundle] to extract the result.
+         */
+        internal const val KEY_RESULT = "BiometricKYCResult"
 
         @JvmStatic
         @JvmOverloads

--- a/lib/src/main/java/com/smileidentity/fragment/DocumentVerificationFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/DocumentVerificationFragment.kt
@@ -13,6 +13,10 @@ import com.smileidentity.fragment.DocumentVerificationFragment.Companion.KEY_REQ
 import com.smileidentity.fragment.DocumentVerificationFragment.Companion.KEY_RESULT
 import com.smileidentity.fragment.DocumentVerificationFragment.Companion.newInstance
 import com.smileidentity.fragment.DocumentVerificationFragment.Companion.resultFromBundle
+import com.smileidentity.fragment.EnhancedDocumentVerificationFragment.Companion.KEY_REQUEST
+import com.smileidentity.fragment.EnhancedDocumentVerificationFragment.Companion.resultFromBundle
+import com.smileidentity.fragment.SmartSelfieEnrollmentFragment.Companion.KEY_REQUEST
+import com.smileidentity.fragment.SmartSelfieEnrollmentFragment.Companion.resultFromBundle
 import com.smileidentity.results.DocumentVerificationResult
 import com.smileidentity.results.SmileIDResult
 import com.smileidentity.util.getParcelableCompat
@@ -62,7 +66,12 @@ import java.io.File
 class DocumentVerificationFragment : Fragment() {
     companion object {
         const val KEY_REQUEST = "DocumentVerificationRequest"
-        const val KEY_RESULT = "DocumentVerificationResult"
+
+        /**
+         * This is internal to prevent partners from accidentally using the wrong key. They only
+         * need [KEY_REQUEST]. Partners should use [resultFromBundle] to extract the result.
+         */
+        internal const val KEY_RESULT = "DocumentVerificationResult"
 
         @JvmStatic
         @JvmOverloads

--- a/lib/src/main/java/com/smileidentity/fragment/EnhancedDocumentVerificationFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/EnhancedDocumentVerificationFragment.kt
@@ -13,6 +13,8 @@ import com.smileidentity.fragment.EnhancedDocumentVerificationFragment.Companion
 import com.smileidentity.fragment.EnhancedDocumentVerificationFragment.Companion.KEY_RESULT
 import com.smileidentity.fragment.EnhancedDocumentVerificationFragment.Companion.newInstance
 import com.smileidentity.fragment.EnhancedDocumentVerificationFragment.Companion.resultFromBundle
+import com.smileidentity.fragment.SmartSelfieEnrollmentFragment.Companion.KEY_REQUEST
+import com.smileidentity.fragment.SmartSelfieEnrollmentFragment.Companion.resultFromBundle
 import com.smileidentity.results.EnhancedDocumentVerificationResult
 import com.smileidentity.results.SmileIDResult
 import com.smileidentity.util.getParcelableCompat
@@ -61,7 +63,12 @@ import kotlinx.collections.immutable.toImmutableMap
 class EnhancedDocumentVerificationFragment : Fragment() {
     companion object {
         const val KEY_REQUEST = "EnhancedDocumentVerificationRequest"
-        const val KEY_RESULT = "EnhancedDocumentVerificationResult"
+
+        /**
+         * This is internal to prevent partners from accidentally using the wrong key. They only
+         * need [KEY_REQUEST]. Partners should use [resultFromBundle] to extract the result.
+         */
+        internal const val KEY_RESULT = "EnhancedDocumentVerificationResult"
 
         @JvmStatic
         @JvmOverloads

--- a/lib/src/main/java/com/smileidentity/fragment/SmartSelfieAuthenticationFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/SmartSelfieAuthenticationFragment.kt
@@ -13,6 +13,8 @@ import com.smileidentity.fragment.SmartSelfieAuthenticationFragment.Companion.KE
 import com.smileidentity.fragment.SmartSelfieAuthenticationFragment.Companion.KEY_RESULT
 import com.smileidentity.fragment.SmartSelfieAuthenticationFragment.Companion.newInstance
 import com.smileidentity.fragment.SmartSelfieAuthenticationFragment.Companion.resultFromBundle
+import com.smileidentity.fragment.SmartSelfieEnrollmentFragment.Companion.KEY_REQUEST
+import com.smileidentity.fragment.SmartSelfieEnrollmentFragment.Companion.resultFromBundle
 import com.smileidentity.results.SmartSelfieResult
 import com.smileidentity.results.SmileIDResult
 import com.smileidentity.util.getParcelableCompat
@@ -58,7 +60,12 @@ import kotlinx.collections.immutable.toImmutableMap
 class SmartSelfieAuthenticationFragment : Fragment() {
     companion object {
         const val KEY_REQUEST = "SmartSelfieAuthenticationRequest"
-        const val KEY_RESULT = "SmartSelfieAuthenticationResult"
+
+        /**
+         * This is internal to prevent partners from accidentally using the wrong key. They only
+         * need [KEY_REQUEST]. Partners should use [resultFromBundle] to extract the result.
+         */
+        internal const val KEY_RESULT = "SmartSelfieAuthenticationResult"
 
         /**
          * Creates a new instance of [SmartSelfieAuthenticationFragment] which wraps the

--- a/lib/src/main/java/com/smileidentity/fragment/SmartSelfieEnrollmentFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/SmartSelfieEnrollmentFragment.kt
@@ -58,7 +58,12 @@ import kotlinx.collections.immutable.toImmutableMap
 class SmartSelfieEnrollmentFragment : Fragment() {
     companion object {
         const val KEY_REQUEST = "SmartSelfieEnrollmentRequest"
-        const val KEY_RESULT = "SmartSelfieEnrollmentResult"
+
+        /**
+         * This is internal to prevent partners from accidentally using the wrong key. They only
+         * need [KEY_REQUEST]. Partners should use [resultFromBundle] to extract the result.
+         */
+        internal const val KEY_RESULT = "SmartSelfieEnrollmentResult"
 
         /**
          * Creates a new instance of [SmartSelfieEnrollmentFragment] which wraps the

--- a/sample/src/main/java/com/smileidentity/sample/activity/JavaActivity.java
+++ b/sample/src/main/java/com/smileidentity/sample/activity/JavaActivity.java
@@ -10,6 +10,7 @@ import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 
+import com.smileidentity.SmileID;
 import com.smileidentity.fragment.DocumentVerificationFragment;
 import com.smileidentity.fragment.EnhancedDocumentVerificationFragment;
 import com.smileidentity.fragment.SmartSelfieAuthenticationFragment;
@@ -35,6 +36,7 @@ public class JavaActivity extends FragmentActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        SmileID.initialize(this);
         setContentView(R.layout.activity_java);
         Toast.makeText(this, "Java Activity", Toast.LENGTH_LONG).show();
         productFragmentContainer = findViewById(R.id.fragment_container);


### PR DESCRIPTION
## Summary

This removes the `KEY_RESULT` constant from the public API of our compatibility Fragments. Its usage was a footgun and easily confused with the similarly named `KEY_REQUEST` -- `KEY_REQUEST` is the correct value to pass for the `requestKey` parameter of `setFragmentResultListener`)

It is okay to remove `KEY_RESULT` because we provide a convenience method, `resultFromBundle` which is what should be used to parse the result out of the Fragment `Bundle`