### PR TITLE
Close previous network request before retrying

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,6 +7,8 @@
           <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Bump Compose BOM to 2024.02.00
 * Made `KEY_RESULT` constants in `Fragment`s `internal` to remove a footgun where the constant was easily confused with `KEY_REQUEST`
+* Fixed a bug where network retries would occasionally fail
 
 ## 10.0.4
 

--- a/lib/src/main/java/com/smileidentity/SmileID.kt
+++ b/lib/src/main/java/com/smileidentity/SmileID.kt
@@ -410,6 +410,9 @@ object SmileID {
                         if (response.code < 500) {
                             return@Interceptor response
                         }
+                        // Must close the response before retrying
+                        // see: https://github.com/square/retrofit/issues/3478
+                        response.close()
                     } catch (e: Exception) {
                         Timber.w(e, "Smile ID SDK network attempt #$attempt failed")
                         // Network failures end up here. These will be retried


### PR DESCRIPTION
Story:https://smile-identity.sentry.io/issues/5140199350/

## Summary

We have to close the previous response body before retrying

https://github.com/square/retrofit/issues/3478
