### PR TITLE
Remove publicly accessible SmartSelfie UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * Added an Offline Mode, enabled by calling `SmileID.setAllowOfflineMode(true)`. If a job is attempted while the device is offline, and offline mode has been enabled, the UI will complete successfully and the job can be submitted at a later time by calling `SmileID.submitJob(jobId)`
 * Improved SmartSelfie Enrollment and Authentication times by moving to a synchronous API endpoint
-* Introduce an experimental new SmartSelfie Authentication UI, available by passing `useExperimentalUi=true` to the `SmileID.SmartSelfieAuthentication` Composable/Fragment
 * Made `KEY_RESULT` constants in `Fragment`s `internal` to remove a footgun where the constant was easily confused with `KEY_REQUEST`
 * Improved back button behavior on image confirmation and processing dialogs
 * Fixed a bug where network retries would occasionally fail

--- a/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
+++ b/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
@@ -99,7 +99,7 @@ fun SmileID.SmartSelfieEnrollment(
  * [Docs](https://docs.usesmileid.com/products/for-individuals-kyc/biometric-authentication)
  *
  * @param userId The user ID to authenticate with the SmartSelfie™ Authentication. This should be
- * an ID that was previously registered via a SmartSelfie™ Enrollment
+ * an ID previously registered via a SmartSelfie™ Enrollment
  * (see: [SmileID.SmartSelfieEnrollment])
  * @param jobId The job ID to associate with the SmartSelfie™ Authentication. Most often, this
  * will correspond to a unique Job ID within your own system. If not provided, a random job ID
@@ -110,8 +110,6 @@ fun SmileID.SmartSelfieEnrollment(
  * @param showAttribution Whether to show the Smile ID attribution or not on the Instructions screen
  * @param showInstructions Whether to deactivate capture screen's instructions for SmartSelfie.
  * @param extraPartnerParams Custom values specific to partners
- * @param useExperimentalUi Whether to use the new experimental UI. Note that not all parameters are
- * supported in the experimental UI.
  * @param colorScheme The color scheme to use for the UI. This is passed in so that we show a Smile
  * ID branded UI by default, but allow the user to override it if they want.
  * @param typography The typography to use for the UI. This is passed in so that we show a Smile ID
@@ -128,11 +126,12 @@ fun SmileID.SmartSelfieAuthentication(
     showAttribution: Boolean = true,
     showInstructions: Boolean = true,
     extraPartnerParams: ImmutableMap<String, String> = persistentMapOf(),
-    useExperimentalUi: Boolean = false,
     colorScheme: ColorScheme = SmileID.colorScheme,
     typography: Typography = SmileID.typography,
     onResult: SmileIDCallback<SmartSelfieResult> = {},
 ) {
+    // TODO: Move this to a function parameter once we decided to expose it
+    val useExperimentalUi = false
     MaterialTheme(colorScheme = colorScheme, typography = typography) {
         if (useExperimentalUi) {
             val context = LocalContext.current

--- a/lib/src/main/java/com/smileidentity/compose/selfie/v2/SelfieCaptureScreenV2.kt
+++ b/lib/src/main/java/com/smileidentity/compose/selfie/v2/SelfieCaptureScreenV2.kt
@@ -60,6 +60,7 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
 import com.smileidentity.R
+import com.smileidentity.SmileIDOptIn
 import com.smileidentity.compose.components.ForceBrightness
 import com.smileidentity.compose.components.roundedRectCornerDashPathEffect
 import com.smileidentity.ml.SelfieQualityModel
@@ -81,6 +82,7 @@ import kotlinx.collections.immutable.persistentMapOf
 const val DEFAULT_CUTOUT_PROPORTION = 0.8f
 
 @OptIn(ExperimentalPermissionsApi::class)
+@SmileIDOptIn
 @Composable
 fun OrchestratedSelfieCaptureScreenV2(
     userId: String,

--- a/lib/src/main/java/com/smileidentity/fragment/SmartSelfieAuthenticationFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/SmartSelfieAuthenticationFragment.kt
@@ -84,8 +84,6 @@ class SmartSelfieAuthenticationFragment : Fragment() {
          * @param showAttribution Whether to show the Smile ID attribution or not.
          * @param showInstructions Whether to show the instructions or not.
          * @param extraPartnerParams Custom values specific to partners
-         * @param useExperimentalUi Whether to use the new experimental UI. Note that not all
-         * parameters are supported in the experimental UI.
          */
         @JvmStatic
         @JvmOverloads
@@ -97,7 +95,6 @@ class SmartSelfieAuthenticationFragment : Fragment() {
             showAttribution: Boolean = true,
             showInstructions: Boolean = true,
             extraPartnerParams: HashMap<String, String>? = null,
-            useExperimentalUi: Boolean = false,
         ) = SmartSelfieAuthenticationFragment().apply {
             arguments = Bundle().apply {
                 this.userId = userId
@@ -107,7 +104,6 @@ class SmartSelfieAuthenticationFragment : Fragment() {
                 this.showAttribution = showAttribution
                 this.showInstructions = showInstructions
                 this.extraPartnerParams = extraPartnerParams
-                this.useExperimentalUi = useExperimentalUi
             }
         }
 
@@ -133,7 +129,6 @@ class SmartSelfieAuthenticationFragment : Fragment() {
                 showAttribution = args.showAttribution,
                 showInstructions = args.showInstructions,
                 extraPartnerParams = (args.extraPartnerParams ?: mapOf()).toImmutableMap(),
-                useExperimentalUi = args.useExperimentalUi,
                 onResult = {
                     setFragmentResult(KEY_REQUEST, Bundle().apply { smileIdResult = it })
                 },
@@ -176,11 +171,6 @@ private const val KEY_EXTRA_PARTNER_PARAMS = "extraPartnerParams"
 private var Bundle.extraPartnerParams: HashMap<String, String>?
     get() = getSerializableCompat(KEY_EXTRA_PARTNER_PARAMS)
     set(value) = putSerializable(KEY_EXTRA_PARTNER_PARAMS, value)
-
-private const val KEY_USE_EXPERIMENTAL_UI = "useExperimentalUi"
-private var Bundle.useExperimentalUi: Boolean
-    get() = getBoolean(KEY_USE_EXPERIMENTAL_UI)
-    set(value) = putBoolean(KEY_USE_EXPERIMENTAL_UI, value)
 
 private var Bundle.smileIdResult: SmileIDResult<SmartSelfieResult>
     get() = getParcelableCompat(KEY_RESULT)!!

--- a/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
+++ b/sample/src/main/java/com/smileidentity/sample/compose/MainScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -60,6 +61,8 @@ import com.smileidentity.compose.DocumentVerification
 import com.smileidentity.compose.EnhancedDocumentVerificationScreen
 import com.smileidentity.compose.SmartSelfieAuthentication
 import com.smileidentity.compose.SmartSelfieEnrollment
+import com.smileidentity.compose.selfie.v2.OrchestratedSelfieCaptureScreenV2
+import com.smileidentity.ml.SelfieQualityModel
 import com.smileidentity.models.IdInfo
 import com.smileidentity.models.JobType
 import com.smileidentity.sample.BottomNavigationScreen
@@ -230,10 +233,16 @@ fun MainScreen(
                 dialog(ProductScreen.SmartSelfieAuthenticationV2.route + "/{userId}") {
                     LaunchedEffect(Unit) { viewModel.onSmartSelfieAuthenticationV2Selected() }
                     val userId = rememberSaveable { it.arguments?.getString("userId")!! }
-                    SmileID.SmartSelfieAuthentication(userId = userId, useExperimentalUi = true) {
-                        viewModel.onSmartSelfieAuthenticationV2Result(it)
-                        navController.popBackStack()
-                    }
+                    val context = LocalContext.current
+                    val selfieQualityModel = remember { SelfieQualityModel.newInstance(context) }
+                    OrchestratedSelfieCaptureScreenV2(
+                        userId = userId,
+                        selfieQualityModel = selfieQualityModel,
+                        onResult = {
+                            viewModel.onSmartSelfieAuthenticationV2Result(it)
+                            navController.popBackStack()
+                        },
+                    )
                 }
                 composable(ProductScreen.EnhancedKyc.route) {
                     LaunchedEffect(Unit) { viewModel.onEnhancedKycSelected() }


### PR DESCRIPTION
## Summary

Removes the new SmartSelfie UI from the publicly accessible SDK interface. It remains in the sample app
