### PR TITLE
Fix indfinite Document Verification Processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+* Fixed a bug where Document Verification would get stuck on the processing screen
+
 ## 10.1.0
 
 * Added an Offline Mode, enabled by calling `SmileID.setAllowOfflineMode(true)`. If a job is attempted while the device is offline, and offline mode has been enabled, the UI will complete successfully and the job can be submitted at a later time by calling `SmileID.submitJob(jobId)`

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
@@ -194,7 +194,7 @@ internal abstract class OrchestratedDocumentViewModel<T : Parcelable>(
         }
     }
 
-    fun sendResult(
+    private fun sendResult(
         documentFrontFile: File,
         documentBackFile: File? = null,
         livenessFiles: List<File>? = null,

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
@@ -70,9 +70,9 @@ internal abstract class OrchestratedDocumentViewModel<T : Parcelable>(
     var result: SmileIDResult<T> = SmileIDResult.Error(
         IllegalStateException("Document Capture incomplete"),
     )
-    protected var documentFrontFile: File? = null
-    protected var documentBackFile: File? = null
-    protected var livenessFiles: List<File>? = null
+    private var documentFrontFile: File? = null
+    private var documentBackFile: File? = null
+    private var livenessFiles: List<File>? = null
     private var stepToRetry: DocumentCaptureFlow? = null
 
     fun onDocumentFrontCaptureSuccess(documentImageFile: File) {
@@ -145,7 +145,7 @@ internal abstract class OrchestratedDocumentViewModel<T : Parcelable>(
                 "Selfie file is null",
             )
             // Liveness files will be null when the partner bypasses our Selfie capture with a file
-            val livenessImageInfo = livenessFiles?.map { it.asLivenessImage() } ?: emptyList()
+            val livenessImageInfo = livenessFiles.orEmpty().map { it.asLivenessImage() }
             val uploadRequest = UploadRequest(
                 images = listOfNotNull(
                     frontImageInfo,
@@ -190,6 +190,7 @@ internal abstract class OrchestratedDocumentViewModel<T : Parcelable>(
             val prepUploadResponse = SmileID.api.prepUpload(prepUploadRequest)
             SmileID.api.upload(prepUploadResponse.uploadUrl, uploadRequest)
             Timber.d("Upload finished")
+            sendResult(documentFrontFile, documentBackFile, livenessFiles)
         }
     }
 
@@ -281,7 +282,7 @@ internal abstract class OrchestratedDocumentViewModel<T : Parcelable>(
     }
 
     /**
-     * If stepToRetry is ProcessingScreen, we're retrying a network issue, so we need to kick off
+     * If [stepToRetry] is ProcessingScreen, we're retrying a network issue, so we need to kick off
      * the resubmission manually. Otherwise, we're retrying a capture error, so we just need to
      * reset the UI state
      */


### PR DESCRIPTION
Sets the processing status to success once the API request completes. Introduced here: https://github.com/smileidentity/android/pull/318/files#diff-938003660e07ac447891364140d5e76f644af33d63d28c14e80e0785764d7d82L172