### PR TITLE
Better error message when the device is low on storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+* Better error message when the device is low on storage
+
 ## 10.1.1
 
 * Fixed a bug where Document Capture would occasionally fail


### PR DESCRIPTION
Story: https://smile-identity.sentry.io/issues/4969953169

Better, more actionable error message for when the device is low on storage