### PR TITLE
chore: Exposed SmartSelfieEnrollment skipApiSubmission argument

### DIFF
--- a/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
+++ b/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
@@ -75,6 +75,7 @@ fun SmileID.SmartSelfieEnrollment(
     extraPartnerParams: ImmutableMap<String, String> = persistentMapOf(),
     colorScheme: ColorScheme = SmileID.colorScheme,
     typography: Typography = SmileID.typography,
+    skipApiSubmission: Boolean = false,
     onResult: SmileIDCallback<SmartSelfieResult> = {},
 ) {
     MaterialTheme(colorScheme = colorScheme, typography = typography) {
@@ -88,6 +89,7 @@ fun SmileID.SmartSelfieEnrollment(
             showAttribution = showAttribution,
             showInstructions = showInstructions,
             extraPartnerParams = extraPartnerParams,
+            skipApiSubmission = skipApiSubmission,
             onResult = onResult,
         )
     }

--- a/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
+++ b/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
@@ -61,6 +61,7 @@ import kotlinx.collections.immutable.persistentMapOf
  * ID branded UI by default, but allow the user to override it if they want.
  * @param typography The typography to use for the UI. This is passed in so that we show a Smile ID
  * branded UI by default, but allow the user to override it if they want.
+ * @param skipApiSubmission Whether to skip submitting the captured selfie data to the server.
  * @param onResult Callback to be invoked when the SmartSelfie™ Enrollment is complete.
  */
 @Composable

--- a/lib/src/main/java/com/smileidentity/fragment/SmartSelfieEnrollmentFragment.kt
+++ b/lib/src/main/java/com/smileidentity/fragment/SmartSelfieEnrollmentFragment.kt
@@ -92,6 +92,7 @@ class SmartSelfieEnrollmentFragment : Fragment() {
             showAttribution: Boolean = true,
             showInstructions: Boolean = true,
             extraPartnerParams: HashMap<String, String>? = null,
+            skipApiSubmission: Boolean = false,
         ) = SmartSelfieEnrollmentFragment().apply {
             arguments = Bundle().apply {
                 this.userId = userId
@@ -101,6 +102,7 @@ class SmartSelfieEnrollmentFragment : Fragment() {
                 this.showAttribution = showAttribution
                 this.showInstructions = showInstructions
                 this.extraPartnerParams = extraPartnerParams
+                this.skipApiSubmission = skipApiSubmission
             }
         }
 
@@ -126,6 +128,7 @@ class SmartSelfieEnrollmentFragment : Fragment() {
                 showAttribution = args.showAttribution,
                 showInstructions = args.showInstructions,
                 extraPartnerParams = (args.extraPartnerParams ?: mapOf()).toImmutableMap(),
+                skipApiSubmission = args.skipApiSubmission,
                 onResult = {
                     setFragmentResult(KEY_REQUEST, Bundle().apply { smileIdResult = it })
                 },
@@ -172,3 +175,8 @@ private var Bundle.extraPartnerParams: HashMap<String, String>?
 private var Bundle.smileIdResult: SmileIDResult<SmartSelfieResult>
     get() = getParcelableCompat(KEY_RESULT)!!
     set(value) = putParcelable(KEY_RESULT, value)
+
+private const val KEY_SKIP_API_SUBMISSION = "skipApiSubmission"
+private var Bundle.skipApiSubmission: Boolean
+    get() = getBoolean(KEY_SKIP_API_SUBMISSION)
+    set(value) = putBoolean(KEY_SKIP_API_SUBMISSION, value)

--- a/lib/src/main/java/com/smileidentity/viewmodel/SelfieViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/SelfieViewModel.kt
@@ -115,6 +115,12 @@ class SelfieViewModel(
     @VisibleForTesting
     internal var shouldAnalyzeImages = true
 
+    @VisibleForTesting
+    internal var shouldSkipApiSubmission: Boolean? = null
+
+    @VisibleForTesting
+    internal var mockSelfieFile: File? = null
+
     private val faceDetectorOptions = FaceDetectorOptions.Builder().apply {
         setPerformanceMode(FaceDetectorOptions.PERFORMANCE_MODE_FAST)
         setLandmarkMode(FaceDetectorOptions.LANDMARK_MODE_NONE)
@@ -254,7 +260,7 @@ class SelfieViewModel(
     }
 
     private fun submitJob(selfieFile: File, livenessFiles: List<File>) {
-        if (skipApiSubmission) {
+        if (shouldSkipApiSubmission ?: skipApiSubmission) {
             result = SmileIDResult.Success(SmartSelfieResult(selfieFile, livenessFiles, null))
             _uiState.update { it.copy(processingState = ProcessingState.Success) }
             return
@@ -387,7 +393,7 @@ class SelfieViewModel(
     }
 
     fun submitJob() {
-        submitJob(selfieFile!!, livenessFiles)
+        submitJob(mockSelfieFile ?: selfieFile!!, livenessFiles)
     }
 
     fun onFinished(callback: SmileIDCallback<SmartSelfieResult>) {


### PR DESCRIPTION
## Summary

This commit adds the implementation to `skipApiSubmission` in the `SmartSelfieEnrollment` flow, which allows users to decide whether or not they want to send submissions to Smile Identity Server.

Story: None

A few sentences/bullet points about the changes
- Exposed `skipApiSubmission` up until `SmileID.SmartSelfieEnrollment` and `SmartSelfieEnrollmentFragment.newInstance`
- Added test case for `skipApiSubmission`

## Known Issues
- Allow users to decide whether or not they want to send submissions to Smile Identity Server.

## Test Instructions
`./gradlew test`


