### PR TITLE
Additional Compose LifecycleOwner workaround

### DIFF
--- a/lib/proguard-rules.pro
+++ b/lib/proguard-rules.pro
@@ -72,3 +72,11 @@
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 
 -keep,allowobfuscation,allowshrinking class com.squareup.moshi.JsonAdapter
+
+# https://issuetracker.google.com/issues/346808608 (TODO: Remove below 2 rules once resolved)
+-if public class androidx.compose.ui.platform.AndroidCompositionLocals_androidKt {
+    public static *** getLocalLifecycleOwner();
+}
+-keep public class androidx.compose.ui.platform.AndroidCompositionLocals_androidKt {
+    public static *** getLocalLifecycleOwner();
+}


### PR DESCRIPTION
## Summary

Google shipped an update in Lifecycle 2.8.2 for the Compose 1.6 incompatibility, but the fix doesn't work when in release mode. Google has acknowledged this in https://issuetracker.google.com/issues/346808608, and the workaround of some additional proguard rules was suggested, which have been added here to ship with our library. They can be removed likely with the next Lifecycle update, or with Compose 1.7