### PR TITLE
Remove dependency submission

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,22 +65,3 @@ jobs:
       - uses: musichin/ktlint-check@v3
         with:
           ktlint-version: "1.2.1"
-
-  dependency-submission:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-      - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v3
-        with:
-          build-scan-publish: true
-          build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
-          build-scan-terms-of-service-agree: "yes"
-        env:
-          ORG_GRADLE_PROJECT_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}


### PR DESCRIPTION
Removes Gradle dependency submission to the Gradle Build Scan service since we get Dependabot security scans in Github