### PR TITLE
Fail active liveness after timeout

### DIFF
--- a/lib/src/main/java/com/smileidentity/models/v2/FailureReason.kt
+++ b/lib/src/main/java/com/smileidentity/models/v2/FailureReason.kt
@@ -1,0 +1,12 @@
+package com.smileidentity.models.v2
+
+import android.os.Parcelable
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonClass(generateAdapter = true)
+data class FailureReason(
+    @Json(name = "mobile_active_liveness_timed_out") val activeLivenessTimedOut: Boolean? = null,
+) : Parcelable

--- a/lib/src/main/java/com/smileidentity/networking/SmileIDService.kt
+++ b/lib/src/main/java/com/smileidentity/networking/SmileIDService.kt
@@ -28,6 +28,7 @@ import com.smileidentity.models.SubmitBvnTotpRequest
 import com.smileidentity.models.SubmitBvnTotpResponse
 import com.smileidentity.models.UploadRequest
 import com.smileidentity.models.ValidDocumentsResponse
+import com.smileidentity.models.v2.FailureReason
 import com.smileidentity.models.v2.Metadata
 import com.smileidentity.models.v2.SmartSelfieResponse
 import java.io.File
@@ -86,6 +87,7 @@ interface SmileIDService {
         @Part("user_id") userId: String? = null,
         @Part("partner_params")
         partnerParams: Map<@JvmSuppressWildcards String, @JvmSuppressWildcards String>? = null,
+        @Part("failure_reason") failureReason: FailureReason? = null,
         @Part("callback_url") callbackUrl: String? = SmileID.callbackUrl.ifBlank { null },
         @Part("sandbox_result") sandboxResult: Int? = null,
         @Part("allow_new_enroll") allowNewEnroll: Boolean? = null,
@@ -110,6 +112,7 @@ interface SmileIDService {
         @Part livenessImages: List<@JvmSuppressWildcards MultipartBody.Part>,
         @Part("partner_params")
         partnerParams: Map<@JvmSuppressWildcards String, @JvmSuppressWildcards String>? = null,
+        @Part("failure_reason") failureReason: FailureReason? = null,
         @Part("callback_url") callbackUrl: String? = SmileID.callbackUrl.ifBlank { null },
         @Part("sandbox_result") sandboxResult: Int? = null,
         @Part("metadata") metadata: Metadata? = Metadata.default(),
@@ -230,6 +233,7 @@ suspend fun SmileIDService.doSmartSelfieEnrollment(
     livenessImages: List<File>,
     userId: String? = null,
     partnerParams: Map<String, String>? = null,
+    failureReason: FailureReason? = null,
     callbackUrl: String? = SmileID.callbackUrl.ifBlank { null },
     sandboxResult: Int? = null,
     allowNewEnroll: Boolean? = null,
@@ -239,6 +243,7 @@ suspend fun SmileIDService.doSmartSelfieEnrollment(
     livenessImages = livenessImages.asFormDataParts("liveness_images", "image/jpeg"),
     userId = userId,
     partnerParams = partnerParams,
+    failureReason = failureReason,
     callbackUrl = callbackUrl,
     sandboxResult = sandboxResult,
     allowNewEnroll = allowNewEnroll,
@@ -262,6 +267,7 @@ suspend fun SmileIDService.doSmartSelfieAuthentication(
     selfieImage: File,
     livenessImages: List<File>,
     partnerParams: Map<String, String>? = null,
+    failureReason: FailureReason? = null,
     callbackUrl: String? = SmileID.callbackUrl.ifBlank { null },
     sandboxResult: Int? = null,
     metadata: Metadata? = Metadata.default(),
@@ -270,6 +276,7 @@ suspend fun SmileIDService.doSmartSelfieAuthentication(
     selfieImage = selfieImage.asFormDataPart("selfie_image", "image/jpeg"),
     livenessImages = livenessImages.asFormDataParts("liveness_images", "image/jpeg"),
     partnerParams = partnerParams,
+    failureReason = failureReason,
     callbackUrl = callbackUrl,
     sandboxResult = sandboxResult,
     metadata = metadata,

--- a/lib/src/main/java/com/smileidentity/viewmodel/SmartSelfieV2ViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/SmartSelfieV2ViewModel.kt
@@ -19,6 +19,7 @@ import com.smileidentity.R
 import com.smileidentity.SmileID
 import com.smileidentity.SmileIDCrashReporting
 import com.smileidentity.ml.SelfieQualityModel
+import com.smileidentity.models.v2.FailureReason
 import com.smileidentity.models.v2.SmartSelfieResponse
 import com.smileidentity.networking.doSmartSelfieAuthentication
 import com.smileidentity.networking.doSmartSelfieEnrollment
@@ -555,6 +556,7 @@ class SmartSelfieV2ViewModel(
                 livenessImages = livenessFiles,
                 allowNewEnroll = allowNewEnroll,
                 partnerParams = extraPartnerParams,
+                failureReason = FailureReason(activeLivenessTimedOut = forcedFailureTimerExpired),
                 metadata = null,
             )
         } else {

--- a/sample/src/main/java/com/smileidentity/sample/viewmodel/MainScreenViewModel.kt
+++ b/sample/src/main/java/com/smileidentity/sample/viewmodel/MainScreenViewModel.kt
@@ -336,7 +336,7 @@ class MainScreenViewModel : ViewModel() {
                     partnerId = SmileID.config.partnerId,
                     isProduction = uiState.value.isProduction,
                     job = Job(
-                        jobType = SmartSelfieAuthentication,
+                        jobType = SmartSelfieEnrollment,
                         timestamp = response.createdAt,
                         userId = response.userId,
                         jobId = response.jobId,
@@ -349,7 +349,7 @@ class MainScreenViewModel : ViewModel() {
             }
         } else if (result is SmileIDResult.Error) {
             val th = result.throwable
-            val message = "SmartSelfie Authentication error: ${th.message}"
+            val message = "SmartSelfie Enrollment error: ${th.message}"
             Timber.e(th, message)
             _uiState.update { it.copy(snackbarMessage = message) }
         }


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/12973

## Summary

Once the active liveness timer expires, the job is submitted with `failure_reason.mobile_active_liveness_timed_out` set to `true`
