### PR TITLE
Updated error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Unreleased
+
+* Fixed a bug where some failed authentication requests were incorrectly handled
+* Fixed a bug where errors with no code were not being handled correctly
+
 ## 10.1.6
 
 * Update generic errors with actual platform errors

--- a/lib/src/main/java/com/smileidentity/models/Models.kt
+++ b/lib/src/main/java/com/smileidentity/models/Models.kt
@@ -10,7 +10,7 @@ import com.squareup.moshi.JsonClass
 import java.io.Serializable
 import kotlinx.parcelize.Parcelize
 
-@Suppress("CanBeParameter", "MemberVisibilityCanBePrivate")
+@Suppress("MemberVisibilityCanBePrivate")
 @Parcelize
 class SmileIDException(val details: Details) : Exception(details.message), Parcelable {
 

--- a/lib/src/main/java/com/smileidentity/networking/SmileHeaderAuthInterceptor.kt
+++ b/lib/src/main/java/com/smileidentity/networking/SmileHeaderAuthInterceptor.kt
@@ -5,6 +5,7 @@ import com.smileidentity.models.AuthenticationRequest
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Request
+import okio.IOException
 import timber.log.Timber
 
 annotation class SmileHeaderAuth
@@ -20,7 +21,19 @@ object SmileHeaderAuthInterceptor : Interceptor {
         request.getCustomAnnotation(SmileHeaderAuth::class.java) ?: return chain.proceed(request)
         Timber.v("SmileHeaderAuthInterceptor: Interceptor called")
         val authResponse = runBlocking {
-            SmileID.api.authenticate(AuthenticationRequest(enrollment = true))
+            try {
+                SmileID.api.authenticate(AuthenticationRequest(enrollment = true))
+            } catch (e: Exception) {
+                // https://stackoverflow.com/a/58711127/3831060
+                // OkHttp only propagates IOExceptions, so we need to catch HttpException (which can
+                // occur when credentials are not valid, for example) and rethrow it, so that the
+                // exception handlers at the application level can handle it. We add the caught
+                // exception as a suppressed exception to the IOException that we throw, so that
+                // [getExceptionHandler] can still access the original exception.
+                throw IOException("Error authenticating request").apply {
+                    addSuppressed(e)
+                }
+            }
         }
         val newRequest = request.newBuilder()
             .header("SmileID-Partner-ID", SmileID.config.partnerId)


### PR DESCRIPTION
Addresses 2 SDK bugs. One where a crash would occur if no code was included in the response. And another where, when using endpoints annotated with `@SmileHeaderAuthInterceptor`, failures in the actual authentication API call were not propagated to the exception handlers set at the application level.

This also addresses another long standing bug in the sample app, where the background job pollers would cause the app to crash if there was no internet.