### PR TITLE
Track document image origin

### DIFF
--- a/lib/lib.gradle.kts
+++ b/lib/lib.gradle.kts
@@ -83,6 +83,11 @@ composeCompiler {
     metricsDestination = layout.buildDirectory.dir("compose_compiler")
 }
 
+moshi {
+    // Opt-in to enable moshi-sealed, disabled by default.
+    enableSealed.set(true)
+}
+
 mavenPublishing {
     publishToMavenCentral(automaticRelease = true)
     signAllPublications()

--- a/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureScreen.kt
+++ b/lib/src/main/java/com/smileidentity/compose/document/DocumentCaptureScreen.kt
@@ -51,6 +51,7 @@ import com.smileidentity.SmileIDCrashReporting
 import com.smileidentity.compose.components.ImageCaptureConfirmationDialog
 import com.smileidentity.compose.preview.Preview
 import com.smileidentity.compose.preview.SmilePreviews
+import com.smileidentity.models.v2.DocumentImageOriginValue
 import com.smileidentity.util.createDocumentFile
 import com.smileidentity.util.isValidDocumentImage
 import com.smileidentity.util.toast
@@ -91,7 +92,7 @@ fun DocumentCaptureScreen(
     instructionsSubtitleText: String,
     captureTitleText: String,
     knownIdAspectRatio: Float?,
-    onConfirm: (File) -> Unit,
+    onConfirm: (File, DocumentImageOriginValue?) -> Unit,
     onError: (Throwable) -> Unit,
     modifier: Modifier = Modifier,
     onSkip: () -> Unit = { },
@@ -163,7 +164,7 @@ fun DocumentCaptureScreen(
                 confirmButtonText = stringResource(
                     id = R.string.si_doc_v_confirmation_dialog_confirm_button,
                 ),
-                onConfirm = { onConfirm(documentImageToConfirm) },
+                onConfirm = { onConfirm(documentImageToConfirm, viewModel.documentImageOrigin) },
                 retakeButtonText = stringResource(
                     id = R.string.si_doc_v_confirmation_dialog_retake_button,
                 ),
@@ -183,7 +184,7 @@ fun DocumentCaptureScreen(
                 areEdgesDetected = uiState.areEdgesDetected,
                 showCaptureInProgress = uiState.showCaptureInProgress,
                 showManualCaptureButton = uiState.showManualCaptureButton,
-                onCaptureClicked = viewModel::captureDocument,
+                onCaptureClicked = viewModel::captureDocumentManually,
                 imageAnalyzer = viewModel::analyze,
                 onFocusEvent = viewModel::onFocusEvent,
                 modifier = modifier,

--- a/lib/src/main/java/com/smileidentity/models/v2/Metadata.kt
+++ b/lib/src/main/java/com/smileidentity/models/v2/Metadata.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.smileidentity.BuildConfig
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import dev.zacsweers.moshix.sealed.annotations.TypeLabel
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -13,12 +14,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class Metadata(val items: List<Metadatum>) : Parcelable {
     companion object {
-        fun default(): Metadata = Metadata(
-            listOf(
-                Metadatum("sdk", "android"),
-                Metadatum("sdk_version", BuildConfig.VERSION_NAME),
-            ),
-        )
+        fun default(): Metadata = Metadata(listOf(Metadatum.Sdk, Metadatum.SdkVersion))
     }
 }
 
@@ -26,8 +22,40 @@ data class Metadata(val items: List<Metadatum>) : Parcelable {
  * key-value pair that can be used to store additional information about a job
  */
 @Parcelize
-@JsonClass(generateAdapter = true)
-data class Metadatum(
-    @Json(name = "name") val name: String,
+@JsonClass(generateAdapter = true, generator = "sealed:name")
+sealed class Metadatum(
     @Json(name = "value") val value: String,
-) : Parcelable
+) : Parcelable {
+    @Parcelize
+    @TypeLabel(label = "sdk")
+    data object Sdk : Metadatum("android")
+
+    @Parcelize
+    @TypeLabel(label = "sdk_version")
+    data object SdkVersion : Metadatum(BuildConfig.VERSION_NAME)
+
+    @Parcelize
+    @TypeLabel(label = "document_front_image_origin")
+    data class DocumentFrontImageOrigin(val origin: DocumentImageOriginValue) :
+        Metadatum(origin.name)
+
+    @Parcelize
+    @TypeLabel(label = "document_back_image_origin")
+    data class DocumentBackImageOrigin(val origin: DocumentImageOriginValue) :
+        Metadatum(origin.name)
+
+    @Parcelize
+    @TypeLabel(label = "camera_facing")
+    data class CameraFacing(val facing: CameraFacingValue) : Metadatum(facing.name)
+}
+
+enum class DocumentImageOriginValue {
+    Gallery,
+    CameraAutoCapture,
+    CameraManualCapture,
+}
+
+enum class CameraFacingValue {
+    Front,
+    Back,
+}

--- a/lib/src/test/java/com/smileidentity/SmileIDTest.kt
+++ b/lib/src/test/java/com/smileidentity/SmileIDTest.kt
@@ -227,7 +227,7 @@ class SmileIDTest {
         every { prepUploadRequestAdapter.fromJson(any<String>()) } returns prepUploadRequest
 
         every {
-            prepUploadRequest.copy(any(), any(), any(), any(), any(), any(), any(), any())
+            prepUploadRequest.copy(any(), any(), any(), any(), any(), any(), any(), any(), any())
         } returns prepUploadRequest
 
         coEvery { api.authenticate(any()) } returns authResponse

--- a/lib/src/test/java/com/smileidentity/viewmodel/document/DocumentViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/document/DocumentViewModelTest.kt
@@ -11,6 +11,7 @@ import com.smileidentity.models.JobType
 import com.smileidentity.models.PartnerParams
 import com.smileidentity.models.PrepUploadResponse
 import com.smileidentity.models.UploadRequest
+import com.smileidentity.models.v2.DocumentImageOriginValue
 import com.smileidentity.results.DocumentVerificationResult
 import com.smileidentity.results.SmartSelfieResult
 import com.smileidentity.results.SmileIDResult
@@ -90,7 +91,7 @@ class DocumentViewModelTest {
         }
 
         // when
-        subject.onDocumentFrontCaptureSuccess(documentFrontFile)
+        subject.onDocumentFrontCaptureSuccess(documentFrontFile, DocumentImageOriginValue.Gallery)
 
         // then
         // the submitJob coroutine won't have finished executing yet, so should still be processing
@@ -109,7 +110,7 @@ class DocumentViewModelTest {
         coEvery { SmileID.api.authenticate(any()) } throws RuntimeException()
 
         // when
-        subject.onDocumentFrontCaptureSuccess(documentFrontFile)
+        subject.onDocumentFrontCaptureSuccess(documentFrontFile, DocumentImageOriginValue.Gallery)
 
         // then
         val currentStep = subject.uiState.value.currentStep
@@ -150,7 +151,7 @@ class DocumentViewModelTest {
         coEvery { SmileID.api.upload(any(), capture(uploadBodySlot)) } just Runs
 
         // when
-        subject.onDocumentFrontCaptureSuccess(documentFrontFile)
+        subject.onDocumentFrontCaptureSuccess(documentFrontFile, DocumentImageOriginValue.Gallery)
 
         // then
         assertNotNull(uploadBodySlot.captured.idInfo)
@@ -195,7 +196,7 @@ class DocumentViewModelTest {
         coEvery { SmileID.api.upload(any(), capture(uploadBodySlot)) } just Runs
 
         // when
-        subject.onDocumentFrontCaptureSuccess(documentFrontFile)
+        subject.onDocumentFrontCaptureSuccess(documentFrontFile, DocumentImageOriginValue.Gallery)
         subject.onSelfieCaptureSuccess(SmileIDResult.Success(selfieResult))
 
         // then

--- a/lib/src/test/java/com/smileidentity/viewmodel/document/EnhancedDocumentVerificationViewModelTest.kt
+++ b/lib/src/test/java/com/smileidentity/viewmodel/document/EnhancedDocumentVerificationViewModelTest.kt
@@ -11,6 +11,7 @@ import com.smileidentity.models.JobType
 import com.smileidentity.models.PartnerParams
 import com.smileidentity.models.PrepUploadResponse
 import com.smileidentity.models.UploadRequest
+import com.smileidentity.models.v2.DocumentImageOriginValue
 import com.smileidentity.results.EnhancedDocumentVerificationResult
 import com.smileidentity.results.SmartSelfieResult
 import com.smileidentity.results.SmileIDResult
@@ -90,7 +91,7 @@ class EnhancedDocumentVerificationViewModelTest {
         }
 
         // when
-        subject.onDocumentFrontCaptureSuccess(documentFrontFile)
+        subject.onDocumentFrontCaptureSuccess(documentFrontFile, DocumentImageOriginValue.Gallery)
 
         // then
         // the submitJob coroutine won't have finished executing yet, so should still be processing
@@ -109,7 +110,7 @@ class EnhancedDocumentVerificationViewModelTest {
         coEvery { SmileID.api.authenticate(any()) } throws RuntimeException()
 
         // when
-        subject.onDocumentFrontCaptureSuccess(documentFrontFile)
+        subject.onDocumentFrontCaptureSuccess(documentFrontFile, DocumentImageOriginValue.Gallery)
 
         // then
         val currentStep = subject.uiState.value.currentStep
@@ -150,7 +151,7 @@ class EnhancedDocumentVerificationViewModelTest {
         coEvery { SmileID.api.upload(any(), capture(uploadBodySlot)) } just Runs
 
         // when
-        subject.onDocumentFrontCaptureSuccess(documentFrontFile)
+        subject.onDocumentFrontCaptureSuccess(documentFrontFile, DocumentImageOriginValue.Gallery)
 
         // then
         assertNotNull(uploadBodySlot.captured.idInfo)
@@ -195,7 +196,7 @@ class EnhancedDocumentVerificationViewModelTest {
         coEvery { SmileID.api.upload(any(), capture(uploadBodySlot)) } just Runs
 
         // when
-        subject.onDocumentFrontCaptureSuccess(documentFrontFile)
+        subject.onDocumentFrontCaptureSuccess(documentFrontFile, DocumentImageOriginValue.Gallery)
         subject.onSelfieCaptureSuccess(SmileIDResult.Success(selfieResult))
 
         // then


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/13073

## Summary

Saves the image origin of a document capture - one of either gallery upload, camera auto capture, or camera manual capture - and sends it as metadata to prepupload

Additionally, this makes `Metadatum` more rigid to only allow known good values

## Known Issues

These metadata keys have not been created on the backend yet