### PR TITLE
Add GitHub Environment to Internal App Sharing builds

### DIFF
--- a/.github/workflows/build_app.yaml
+++ b/.github/workflows/build_app.yaml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: Play Store Internal App Sharing
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds an environment to the internal app sharing github action: https://github.com/smileidentity/android/settings/environments/3393136261/edit