### PR TITLE
Place all Composable content within a Surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Release Notes
 
+## Unreleased
+
+* Wrap Composables in a `Surface` for additional background color customization
 
 ## 10.2.0
+
 * Added an optional "Strict Mode" to SmartSelfie Enrollment and Authentication to achieve better pass rates. Set `useStrictMode=true` to enable this new, streamlined UI and associated active liveness tasks
 
 ## 10.1.7
+
 * Fixed a bug where some failed authentication requests were incorrectly handled
 * Fixed a bug where errors with no code were not being handled correctly
 * Fixed a bug on Selfie and Document capture success screen where the message was wrong

--- a/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
+++ b/lib/src/main/java/com/smileidentity/compose/SmileIDExt.kt
@@ -3,7 +3,6 @@
 package com.smileidentity.compose
 
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -14,6 +13,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.smileidentity.SmileID
 import com.smileidentity.compose.biometric.OrchestratedBiometricKYCScreen
+import com.smileidentity.compose.components.SmileThemeSurface
 import com.smileidentity.compose.consent.OrchestratedConsentScreen
 import com.smileidentity.compose.consent.bvn.OrchestratedBvnConsentScreen
 import com.smileidentity.compose.document.OrchestratedDocumentVerificationScreen
@@ -80,7 +80,7 @@ fun SmileID.SmartSelfieEnrollment(
     typography: Typography = SmileID.typography,
     onResult: SmileIDCallback<SmartSelfieResult> = {},
 ) {
-    MaterialTheme(colorScheme = colorScheme, typography = typography) {
+    SmileThemeSurface(colorScheme = colorScheme, typography = typography) {
         // TODO: Eventually use the new UI even for nonStrictMode, but with active liveness disabled
         if (useStrictMode) {
             val context = LocalContext.current
@@ -154,7 +154,7 @@ fun SmileID.SmartSelfieAuthentication(
     typography: Typography = SmileID.typography,
     onResult: SmileIDCallback<SmartSelfieResult> = {},
 ) {
-    MaterialTheme(colorScheme = colorScheme, typography = typography) {
+    SmileThemeSurface(colorScheme = colorScheme, typography = typography) {
         // TODO: Eventually use the new UI even for nonStrictMode, but with active liveness disabled
         if (useStrictMode) {
             val context = LocalContext.current
@@ -241,7 +241,7 @@ fun SmileID.DocumentVerification(
     typography: Typography = SmileID.typography,
     onResult: SmileIDCallback<DocumentVerificationResult> = {},
 ) {
-    MaterialTheme(colorScheme = colorScheme, typography = typography) {
+    SmileThemeSurface(colorScheme = colorScheme, typography = typography) {
         OrchestratedDocumentVerificationScreen(
             modifier = modifier,
             userId = userId,
@@ -326,7 +326,7 @@ fun SmileID.EnhancedDocumentVerificationScreen(
     typography: Typography = SmileID.typography,
     onResult: SmileIDCallback<EnhancedDocumentVerificationResult> = {},
 ) {
-    MaterialTheme(colorScheme = colorScheme, typography = typography) {
+    SmileThemeSurface(colorScheme = colorScheme, typography = typography) {
         OrchestratedDocumentVerificationScreen(
             modifier = modifier,
             userId = userId,
@@ -395,7 +395,7 @@ fun SmileID.BiometricKYC(
     typography: Typography = SmileID.typography,
     onResult: SmileIDCallback<BiometricKycResult> = {},
 ) {
-    MaterialTheme(colorScheme = colorScheme, typography = typography) {
+    SmileThemeSurface(colorScheme = colorScheme, typography = typography) {
         OrchestratedBiometricKYCScreen(
             modifier = modifier,
             idInfo = idInfo,
@@ -443,7 +443,7 @@ fun SmileID.BvnConsentScreen(
     colorScheme: ColorScheme = SmileID.colorScheme,
     typography: Typography = SmileID.typography,
 ) {
-    MaterialTheme(colorScheme = colorScheme, typography = typography) {
+    SmileThemeSurface(colorScheme = colorScheme, typography = typography) {
         OrchestratedBvnConsentScreen(
             modifier = modifier,
             userId = userId,
@@ -468,7 +468,7 @@ fun SmileID.ConsentScreen(
     modifier: Modifier = Modifier,
     showAttribution: Boolean = true,
 ) {
-    MaterialTheme(colorScheme = colorScheme, typography = typography) {
+    SmileThemeSurface(colorScheme = colorScheme, typography = typography) {
         OrchestratedConsentScreen(
             partnerIcon = partnerIcon,
             partnerName = partnerName,

--- a/lib/src/main/java/com/smileidentity/compose/components/SmileThemeSurface.kt
+++ b/lib/src/main/java/com/smileidentity/compose/components/SmileThemeSurface.kt
@@ -1,0 +1,18 @@
+package com.smileidentity.compose.components
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Typography
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun SmileThemeSurface(
+    colorScheme: ColorScheme,
+    typography: Typography,
+    content: @Composable () -> Unit,
+) {
+    MaterialTheme(colorScheme = colorScheme, typography = typography) {
+        Surface(content = content)
+    }
+}

--- a/lib/src/main/res/values/colors.xml
+++ b/lib/src/main/res/values/colors.xml
@@ -27,7 +27,7 @@
     <color name="si_color_material_on_tertiary_container">@color/si_color_on_light</color>
     <color name="si_color_material_background">@color/si_color_background_main</color>
     <color name="si_color_material_on_background">@color/si_color_on_light</color>
-    <color name="si_color_material_surface">@color/si_color_background_dark</color>
+    <color name="si_color_material_surface">@color/si_color_background_main</color>
     <color name="si_color_material_on_surface">@color/si_color_on_light</color>
     <color name="si_color_material_surface_variant">@color/si_color_background_light</color>
     <color name="si_color_material_on_surface_variant">@color/si_color_on_light</color>


### PR DESCRIPTION
Place all Composables within a Surface, so that changing the value of `si_color_background_main` changes the background color.

Also introduces a new `SmileThemeSurface` helper Composable, which consolidates the common `MaterialTheme`+`Surface` usage.  It will also be helpful in making https://github.com/smileidentity/android/pull/402 more as we can encompass `CompositionLocalProvider` in it