### PR TITLE
Set retry flag on error code 2215

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+* Fixed a bug where `SmileID.submitJob` would not work for previously attempted API requests
+
 ## 10.2.1
 
 * Wrap Composables in a `Surface` for additional background color customization

--- a/lib/src/main/java/com/smileidentity/SmileID.kt
+++ b/lib/src/main/java/com/smileidentity/SmileID.kt
@@ -343,6 +343,8 @@ object SmileID {
         val prepUploadResponse = try {
             api.prepUpload(prepUploadRequest)
         } catch (e: SmileIDException) {
+            // It may be the case that Prep Upload was called during the job but the link expired.
+            // We need to pass retry=true in order to obtain a new link
             if (e.details.code == "2215") {
                 api.prepUpload(prepUploadRequest.copy(retry = true))
             } else {

--- a/lib/src/main/java/com/smileidentity/SmileID.kt
+++ b/lib/src/main/java/com/smileidentity/SmileID.kt
@@ -15,6 +15,7 @@ import com.smileidentity.models.Config
 import com.smileidentity.models.IdInfo
 import com.smileidentity.models.JobType
 import com.smileidentity.models.PrepUploadRequest
+import com.smileidentity.models.SmileIDException
 import com.smileidentity.models.UploadRequest
 import com.smileidentity.networking.BiometricKycJobResultAdapter
 import com.smileidentity.networking.DocumentVerificationJobResultAdapter
@@ -339,7 +340,15 @@ object SmileID {
             signature = authResponse.signature,
         )
 
-        val prepUploadResponse = api.prepUpload(prepUploadRequest)
+        val prepUploadResponse = try {
+            api.prepUpload(prepUploadRequest)
+        } catch (e: SmileIDException) {
+            if (e.details.code == "2215") {
+                api.prepUpload(prepUploadRequest.copy(retry = true))
+            } else {
+                throw e
+            }
+        }
 
         val selfieFileResult = getFileByType(jobId, FileType.SELFIE, submitted = false)
         val livenessFilesResult = getFilesByType(jobId, FileType.LIVENESS, submitted = false)

--- a/lib/src/main/java/com/smileidentity/models/PrepUpload.kt
+++ b/lib/src/main/java/com/smileidentity/models/PrepUpload.kt
@@ -18,6 +18,7 @@ data class PrepUploadRequest(
     @Json(name = "allow_new_enroll") val allowNewEnroll: String,
     @Json(name = "smile_client_id") val partnerId: String = SmileID.config.partnerId,
     @Json(name = "metadata") val metadata: List<Metadatum>? = null,
+    @Json(name = "retry") val retry: Boolean? = null,
     @Json(name = "source_sdk") val sourceSdk: String = "android",
     @Json(name = "source_sdk_version") val sourceSdkVersion: String = BuildConfig.VERSION_NAME,
     @Json(name = "timestamp") val timestamp: String = System.currentTimeMillis().toString(),

--- a/lib/src/test/java/com/smileidentity/SmileIDTest.kt
+++ b/lib/src/test/java/com/smileidentity/SmileIDTest.kt
@@ -227,7 +227,18 @@ class SmileIDTest {
         every { prepUploadRequestAdapter.fromJson(any<String>()) } returns prepUploadRequest
 
         every {
-            prepUploadRequest.copy(any(), any(), any(), any(), any(), any(), any(), any(), any())
+            prepUploadRequest.copy(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
         } returns prepUploadRequest
 
         coEvery { api.authenticate(any()) } returns authResponse


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/13152

## Summary

The link returned by Prep Upload has an expiration. However, the job is still considered created at the time the link expires. So, if the user encounters a scenario where prep upload succeeds but upload fails, and the partner app's implementation tries again using `SmileID.submitJob`, it currently fails with error code 2215. 


With this change, we check for this error code explicitly and set the retry flag to true so that we can obtain a new upload URL