### PR TITLE
Handle invalid resource IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 10.2.3 (Unreleased)
+
+* Handle invalid resource IDs
+
 ## 10.2.2
 
 * Fixed a bug where the `BiometricKycViewModel` would succeed but use the default error message as it was not being updated when changing state

--- a/lib/src/main/java/com/smileidentity/util/Util.kt
+++ b/lib/src/main/java/com/smileidentity/util/Util.kt
@@ -2,6 +2,7 @@ package com.smileidentity.util
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Bitmap.CompressFormat.JPEG
 import android.graphics.BitmapFactory
@@ -295,8 +296,13 @@ sealed interface StringResource {
                     context.packageName,
                 )
 
-                return stringResource(id = resourceId).takeIf { it.isNotEmpty() }
-                    ?: exception.details.message
+                return try {
+                    context.resources.getString(resourceId).takeIf { it.isNotEmpty() }
+                        ?: exception.details.message
+                } catch (e: Resources.NotFoundException) {
+                    Timber.w("Got error code whose message can't be overridden")
+                    exception.details.message
+                }
             }
             is Text -> text
         }


### PR DESCRIPTION
## Summary

If we get an error code that we haven't explictly added the ability to override the message for, then we receive an invalid resource identifier. We have to switch away from `stringResource` because it is a `@Composable` function, which cannot be wrapped with a try-catch. However, we have a `context` in scope, so we can use the normal `context.resources.getString` instead, and catch a NotFoundException and default to the returned message

Originally introduced here: https://github.com/smileidentity/android/pull/374#discussion_r162857029