### PR TITLE
Enable manual workflow trigger

### DIFF
--- a/.github/workflows/publish_play_store_update.yaml
+++ b/.github/workflows/publish_play_store_update.yaml
@@ -2,6 +2,7 @@ name: Publish Play Store Update
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

* Add `workflow_dispatch` to github action so that it can be triggered manually.

## Known Issues

N/A.

## Test Instructions

N/A.

## Screenshot

N/A.
