### PR TITLE
Fix/allow new enroll as bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## Unreleased
+* Changes the `allow_new_enroll` flag to be a real boolean instead of a string for prepUpload requests and multi-part requests. This is a breaking change for stored offline jobs, where the job is written using an older sdk version and then submission is attempted using this version.
+
 ## 10.5.2
 
 * Added Enhanced SmartSelfie™ Capture for enroll and authentication fragments 

--- a/lib/src/main/java/com/smileidentity/models/PrepUpload.kt
+++ b/lib/src/main/java/com/smileidentity/models/PrepUpload.kt
@@ -15,8 +15,7 @@ data class PrepUploadRequest(
     @Json(name = "partner_params") val partnerParams: PartnerParams,
     // Callback URL *must* be defined either within your Partner Portal or here
     @Json(name = "callback_url") val callbackUrl: String? = SmileID.callbackUrl,
-    // TODO - Michael will change this to a boolean
-    @Json(name = "allow_new_enroll") val allowNewEnroll: String,
+    @Json(name = "allow_new_enroll") val allowNewEnroll: Boolean,
     @Json(name = "smile_client_id") val partnerId: String = SmileID.config.partnerId,
     @Json(name = "metadata") val metadata: List<Metadatum>? = null,
     @Json(name = "retry") val retry: Boolean? = null,

--- a/lib/src/main/java/com/smileidentity/viewmodel/BiometricKycViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/BiometricKycViewModel.kt
@@ -131,7 +131,7 @@ class BiometricKycViewModel(
                             userId = userId,
                             extras = extraPartnerParams,
                         ),
-                        allowNewEnroll = allowNewEnroll.toString(),
+                        allowNewEnroll = allowNewEnroll,
                         timestamp = "",
                         signature = "",
                     ),
@@ -151,8 +151,7 @@ class BiometricKycViewModel(
 
             val prepUploadRequest = PrepUploadRequest(
                 partnerParams = authResponse.partnerParams.copy(extras = extraPartnerParams),
-                // TODO : Michael will change this to boolean
-                allowNewEnroll = allowNewEnroll.toString(),
+                allowNewEnroll = allowNewEnroll,
                 signature = authResponse.signature,
                 timestamp = authResponse.timestamp,
             )

--- a/lib/src/main/java/com/smileidentity/viewmodel/SelfieViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/SelfieViewModel.kt
@@ -350,7 +350,7 @@ class SelfieViewModel(
                             userId = userId,
                             extras = extraPartnerParams,
                         ),
-                        allowNewEnroll = allowNewEnroll.toString(),
+                        allowNewEnroll = allowNewEnroll,
                         metadata = metadata,
                         timestamp = "",
                         signature = "",

--- a/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
+++ b/lib/src/main/java/com/smileidentity/viewmodel/document/OrchestratedDocumentViewModel.kt
@@ -167,7 +167,7 @@ internal abstract class OrchestratedDocumentViewModel<T : Parcelable>(
                             userId = userId,
                             extras = extraPartnerParams,
                         ),
-                        allowNewEnroll = allowNewEnroll.toString(),
+                        allowNewEnroll = allowNewEnroll,
                         metadata = metadata,
                         timestamp = "",
                         signature = "",
@@ -183,8 +183,7 @@ internal abstract class OrchestratedDocumentViewModel<T : Parcelable>(
 
             val prepUploadRequest = PrepUploadRequest(
                 partnerParams = authResponse.partnerParams.copy(extras = extraPartnerParams),
-                // TODO : Michael will change this to boolean
-                allowNewEnroll = allowNewEnroll.toString(),
+                allowNewEnroll = allowNewEnroll,
                 metadata = metadata,
                 signature = authResponse.signature,
                 timestamp = authResponse.timestamp,


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary
This PR changes the allow_new_enroll flag that is sent in the prepupload /upload and in the multi-part upload requests. It also changes the way how we store the prepUpload request in case of offline mode and this is a breaking change in case someone has a job stored and updates the app inbetween.

## Known Issues
Breaking change in case of stored offline job.

## Test Instructions
Run a biometric kyc job or a selfie enrollment job and check if the flag is a bool instead of a string.

## Screenshot
-
