### PR TITLE
Fix: Skip snapshot publishing for Dependabot PRs using PR author check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
           ORG_GRADLE_PROJECT_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Publish Snapshot
-        if: github.actor != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

Updated the condition to reliably skip publishing snapshots on Dependabot PRs by checking the pull request author instead of the GitHub actor.

## Known Issues

Any shortcomings in your work. This may include corner cases not correctly handled or issues related
to but not within the scope of your PR. Design compromises should be discussed here if they were not
already discussed above.

## Test Instructions

Concise test instructions on how to verify that your feature works as intended. This should include
changes to the development environment (if applicable) and all commands needed to run your work.

## Screenshot

If applicable (e.g. UI changes), add screenshots to help explain your work.
